### PR TITLE
Paging: Fix tests and module exports

### DIFF
--- a/src/aarch64/pagetablestore.rs
+++ b/src/aarch64/pagetablestore.rs
@@ -105,7 +105,7 @@ impl AArch64PageTableEntry {
         match self.level {
             PageLevel::Lvl0 | PageLevel::Lvl1 | PageLevel::Lvl2 => {
                 let entry = unsafe { get_entry::<VMSAv864TableDescriptor>(self.page_base, self.index) };
-                entry.update_fields(attributes, pa.into())
+                entry.update_fields(attributes, pa)
             }
             PageLevel::Lvl3 => {
                 let entry = unsafe { get_entry::<VMSAv864PageDescriptor>(self.page_base, self.index) };

--- a/src/aarch64/paging.rs
+++ b/src/aarch64/paging.rs
@@ -302,11 +302,7 @@ impl AArch64PageTable {
                 );
             }
 
-            if sctlr & 0x1 == 1 {
-                true
-            } else {
-                false
-            }
+            sctlr & 0x1 == 1
         }
     }
 
@@ -341,9 +337,7 @@ impl PageTable for AArch64PageTable {
 
         // println!("start {:X} end {:X}", start_va, end_va);
 
-        let result = self.map_memory_region_internal(start_va, end_va, self.highest_page_level, self.base, attributes);
-
-        result
+        self.map_memory_region_internal(start_va, end_va, self.highest_page_level, self.base, attributes)
     }
 
     fn unmap_memory_region(&mut self, address: u64, size: u64) -> PtResult<()> {
@@ -354,9 +348,7 @@ impl PageTable for AArch64PageTable {
         let start_va = address;
         let end_va = address + size - 1;
 
-        let result = self.unmap_memory_region_internal(start_va, end_va, self.highest_page_level, self.base);
-
-        result
+        self.unmap_memory_region_internal(start_va, end_va, self.highest_page_level, self.base)
     }
 
     fn install_page_table(&self) -> PtResult<()> {
@@ -379,10 +371,7 @@ impl PageTable for AArch64PageTable {
         let mut prev_attributes = 0;
         self.query_memory_region_internal(start_va, end_va, self.highest_page_level, self.base, &mut prev_attributes)?;
 
-        let result =
-            self.remap_memory_region_internal(start_va, end_va, self.highest_page_level, self.base, attributes);
-
-        result
+        self.remap_memory_region_internal(start_va, end_va, self.highest_page_level, self.base, attributes)
     }
 
     fn query_memory_region(&self, address: u64, size: u64) -> PtResult<u64> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,9 @@
 
 use page_table_error::PtResult;
 extern crate alloc;
-#[cfg(any(feature = "doc", all(target_os = "uefi", target_arch = "aarch64"), test))]
 pub mod aarch64;
 pub mod page_allocator;
 pub mod page_table_error;
-#[cfg(any(feature = "doc", all(target_os = "uefi", target_arch = "x86_64"), test))]
 pub mod x64;
 
 // Cache attributes

--- a/src/tests/aarch64_paging_tests.rs
+++ b/src/tests/aarch64_paging_tests.rs
@@ -74,7 +74,7 @@ fn test_find_num_page_tables() {
 
     let page_allocator = Box::new(TestPageAllocator::new(max_pages, PagingType::AArch64PageTable4KB));
 
-    let pt = AArch64PageTable::new(page_allocator, PagingType::AArch64PageTable4KB);
+    let pt = AArch64PageTable::new(page_allocator.clone(), PagingType::AArch64PageTable4KB);
 
     assert!(pt.is_ok());
 
@@ -139,7 +139,7 @@ fn test_map_memory_address_simple() {
 
         let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
 
-        let pt = AArch64PageTable::new(page_allocator, paging_type);
+        let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
         assert!(pt.is_ok());
         let mut pt = pt.unwrap();
@@ -174,7 +174,7 @@ fn test_map_memory_address_0_to_ffff_ffff() {
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
 
-            let pt = AArch64PageTable::new(page_allocator, paging_type);
+            let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -220,7 +220,7 @@ fn test_map_memory_address_single_page_from_0_to_ffff_ffff() {
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
 
-            let pt = AArch64PageTable::new(page_allocator, paging_type);
+            let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -262,7 +262,7 @@ fn test_map_memory_address_multiple_page_from_0_to_ffff_ffff() {
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
 
-            let pt = AArch64PageTable::new(page_allocator, paging_type);
+            let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -296,7 +296,7 @@ fn test_map_memory_address_unaligned() {
 
         let page_allocator = Box::new(TestPageAllocator::new(max_pages, paging_type));
 
-        let pt = AArch64PageTable::new(page_allocator, paging_type);
+        let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
         assert!(pt.is_ok());
         let mut pt = pt.unwrap();
@@ -325,7 +325,7 @@ fn test_map_memory_address_zero_size() {
 
         let page_allocator = Box::new(TestPageAllocator::new(max_pages, paging_type));
 
-        let pt = AArch64PageTable::new(page_allocator, paging_type);
+        let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
         assert!(pt.is_ok());
         let mut pt = pt.unwrap();
@@ -361,7 +361,7 @@ fn test_unmap_memory_address_simple() {
 
         let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
 
-        let pt = AArch64PageTable::new(page_allocator, paging_type);
+        let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
         assert!(pt.is_ok());
         let mut pt = pt.unwrap();
@@ -395,7 +395,7 @@ fn test_unmap_memory_address_0_to_ffff_ffff() {
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
 
-            let pt = AArch64PageTable::new(page_allocator, paging_type);
+            let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -438,7 +438,7 @@ fn test_unmap_memory_address_single_page_from_0_to_ffff_ffff() {
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
 
-            let pt = AArch64PageTable::new(page_allocator, paging_type);
+            let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -479,7 +479,7 @@ fn test_unmap_memory_address_multiple_page_from_0_to_ffff_ffff() {
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
 
-            let pt = AArch64PageTable::new(page_allocator, paging_type);
+            let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -513,7 +513,7 @@ fn test_unmap_memory_address_unaligned() {
 
         let page_allocator = Box::new(TestPageAllocator::new(max_pages, paging_type));
 
-        let pt = AArch64PageTable::new(page_allocator, paging_type);
+        let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
         assert!(pt.is_ok());
         let mut pt = pt.unwrap();
@@ -540,7 +540,7 @@ fn test_unmap_memory_address_zero_size() {
 
         let page_allocator = Box::new(TestPageAllocator::new(max_pages, paging_type));
 
-        let pt = AArch64PageTable::new(page_allocator, paging_type);
+        let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
         assert!(pt.is_ok());
         let mut pt = pt.unwrap();
@@ -574,7 +574,7 @@ fn test_query_memory_address_simple() {
 
         let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
 
-        let pt = AArch64PageTable::new(page_allocator, paging_type);
+        let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
         assert!(pt.is_ok());
         let mut pt = pt.unwrap();
@@ -608,7 +608,7 @@ fn test_query_memory_address_0_to_ffff_ffff() {
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
 
-            let pt = AArch64PageTable::new(page_allocator, paging_type);
+            let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -649,7 +649,7 @@ fn test_query_memory_address_single_page_from_0_to_ffff_ffff() {
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
 
-            let pt = AArch64PageTable::new(page_allocator, paging_type);
+            let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -689,7 +689,7 @@ fn test_query_memory_address_multiple_page_from_0_to_ffff_ffff() {
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
 
-            let pt = AArch64PageTable::new(page_allocator, paging_type);
+            let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -712,7 +712,7 @@ fn test_query_memory_address_unaligned() {
 
     let page_allocator = Box::new(TestPageAllocator::new(max_pages, PagingType::AArch64PageTable4KB));
 
-    let pt = AArch64PageTable::new(page_allocator, PagingType::AArch64PageTable4KB);
+    let pt = AArch64PageTable::new(page_allocator.clone(), PagingType::AArch64PageTable4KB);
 
     assert!(pt.is_ok());
     let pt = pt.unwrap();
@@ -730,7 +730,7 @@ fn test_query_memory_address_zero_size() {
 
     let page_allocator = Box::new(TestPageAllocator::new(max_pages, PagingType::AArch64PageTable4KB));
 
-    let pt = AArch64PageTable::new(page_allocator, PagingType::AArch64PageTable4KB);
+    let pt = AArch64PageTable::new(page_allocator.clone(), PagingType::AArch64PageTable4KB);
 
     assert!(pt.is_ok());
     let pt = pt.unwrap();
@@ -765,7 +765,7 @@ fn test_remap_memory_address_simple() {
 
         let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
 
-        let pt = AArch64PageTable::new(page_allocator, paging_type);
+        let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
         assert!(pt.is_ok());
         let mut pt = pt.unwrap();
@@ -800,7 +800,7 @@ fn test_remap_memory_address_0_to_ffff_ffff() {
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
 
-            let pt = AArch64PageTable::new(page_allocator, paging_type);
+            let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -844,7 +844,7 @@ fn test_remap_memory_address_single_page_from_0_to_ffff_ffff() {
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
 
-            let pt = AArch64PageTable::new(page_allocator, paging_type);
+            let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -886,7 +886,7 @@ fn test_remap_memory_address_multiple_page_from_0_to_ffff_ffff() {
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
 
-            let pt = AArch64PageTable::new(page_allocator, paging_type);
+            let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -920,7 +920,7 @@ fn test_remap_memory_address_unaligned() {
 
         let page_allocator = Box::new(TestPageAllocator::new(max_pages, paging_type));
 
-        let pt = AArch64PageTable::new(page_allocator, paging_type);
+        let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
         assert!(pt.is_ok());
         let mut pt = pt.unwrap();
@@ -949,7 +949,7 @@ fn test_remap_memory_address_zero_size() {
 
         let page_allocator = Box::new(TestPageAllocator::new(max_pages, paging_type));
 
-        let pt = AArch64PageTable::new(page_allocator, paging_type);
+        let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
 
         assert!(pt.is_ok());
         let mut pt = pt.unwrap();

--- a/src/tests/x64_paging_tests.rs
+++ b/src/tests/x64_paging_tests.rs
@@ -74,7 +74,7 @@ fn test_find_num_page_tables() {
     let max_pages: u64 = 10;
 
     let page_allocator = Box::new(TestPageAllocator::new(max_pages, PagingType::Paging4KB4Level));
-    let pt = X64PageTable::new(page_allocator, PagingType::Paging4KB4Level);
+    let pt = X64PageTable::new(page_allocator.clone(), PagingType::Paging4KB4Level);
 
     assert!(pt.is_ok());
 
@@ -141,7 +141,7 @@ fn test_map_memory_address_simple() {
         // println!("num pages: {} address: {:x} size: {:x}", num_pages, address, size);
 
         let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
-        let pt = X64PageTable::new(page_allocator, paging_type);
+        let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
         assert!(pt.is_ok());
         let mut pt = pt.unwrap();
@@ -178,7 +178,7 @@ fn test_map_memory_address_0_to_ffff_ffff() {
             // println!("num pages: {} address: {:x} size: {:x}", num_pages, address, size);
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
-            let pt = X64PageTable::new(page_allocator, paging_type);
+            let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -228,7 +228,7 @@ fn test_map_memory_address_single_page_from_0_to_ffff_ffff() {
             // println!("num pages: {} address: {:x} size: {:x}", num_pages, address, size);
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
-            let pt = X64PageTable::new(page_allocator, paging_type);
+            let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -277,7 +277,7 @@ fn test_map_memory_address_multiple_page_from_0_to_ffff_ffff() {
             // println!("num pages: {} address: {:x} size: {:x}", num_pages, address, size);
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
-            let pt = X64PageTable::new(page_allocator, paging_type);
+            let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -313,7 +313,7 @@ fn test_map_memory_address_unaligned() {
         let max_pages: u64 = 10;
 
         let page_allocator = Box::new(TestPageAllocator::new(max_pages, paging_type));
-        let pt = X64PageTable::new(page_allocator, paging_type);
+        let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
         assert!(pt.is_ok());
         let mut pt = pt.unwrap();
@@ -344,7 +344,7 @@ fn test_map_memory_address_zero_size() {
         let max_pages: u64 = 10;
 
         let page_allocator = Box::new(TestPageAllocator::new(max_pages, paging_type));
-        let pt = X64PageTable::new(page_allocator, paging_type);
+        let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
         assert!(pt.is_ok());
         let mut pt = pt.unwrap();
@@ -378,7 +378,7 @@ fn test_unmap_memory_address_simple() {
         // println!("num pages: {} address: {:x} size: {:x}", num_pages, address, size);
 
         let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
-        let pt = X64PageTable::new(page_allocator, paging_type);
+        let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
         assert!(pt.is_ok());
         let mut pt = pt.unwrap();
@@ -414,7 +414,7 @@ fn test_unmap_memory_address_0_to_ffff_ffff() {
             // println!("num pages: {} address: {:x} size: {:x}", num_pages, address, size);
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
-            let pt = X64PageTable::new(page_allocator, paging_type);
+            let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -464,7 +464,7 @@ fn test_unmap_memory_address_single_page_from_0_to_ffff_ffff() {
             // println!("num pages: {} address: {:x} size: {:x}", num_pages, address, size);
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
-            let pt = X64PageTable::new(page_allocator, paging_type);
+            let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -512,7 +512,7 @@ fn test_unmap_memory_address_multiple_page_from_0_to_ffff_ffff() {
             // println!("num pages: {} address: {:x} size: {:x}", num_pages, address, size);
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
-            let pt = X64PageTable::new(page_allocator, paging_type);
+            let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -548,7 +548,7 @@ fn test_unmap_memory_address_unaligned() {
         let max_pages: u64 = 10;
 
         let page_allocator = Box::new(TestPageAllocator::new(max_pages, paging_type));
-        let pt = X64PageTable::new(page_allocator, paging_type);
+        let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
         assert!(pt.is_ok());
         let mut pt = pt.unwrap();
@@ -577,7 +577,7 @@ fn test_unmap_memory_address_zero_size() {
         let max_pages: u64 = 10;
 
         let page_allocator = Box::new(TestPageAllocator::new(max_pages, paging_type));
-        let pt = X64PageTable::new(page_allocator, paging_type);
+        let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
         assert!(pt.is_ok());
         let mut pt = pt.unwrap();
@@ -609,7 +609,7 @@ fn test_query_memory_address_simple() {
         // println!("num pages: {} address: {:x} size: {:x}", num_pages, address, size);
 
         let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
-        let pt = X64PageTable::new(page_allocator, paging_type);
+        let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
         assert!(pt.is_ok());
         let mut pt = pt.unwrap();
@@ -644,7 +644,7 @@ fn test_query_memory_address_0_to_ffff_ffff() {
             // println!("num pages: {} address: {:x} size: {:x}", num_pages, address, size);
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
-            let pt = X64PageTable::new(page_allocator, paging_type);
+            let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -682,7 +682,7 @@ fn test_query_memory_address_single_page_from_0_to_ffff_ffff() {
             // println!("num pages: {} address: {:x} size: {:x}", num_pages, address, size);
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
-            let pt = X64PageTable::new(page_allocator, paging_type);
+            let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -729,7 +729,7 @@ fn test_query_memory_address_multiple_page_from_0_to_ffff_ffff() {
             // println!("num pages: {} address: {:x} size: {:x}", num_pages, address, size);
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
-            let pt = X64PageTable::new(page_allocator, paging_type);
+            let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -752,7 +752,7 @@ fn test_query_memory_address_unaligned() {
 
     let page_allocator = Box::new(TestPageAllocator::new(max_pages, PagingType::Paging4KB4Level));
 
-    let pt = X64PageTable::new(page_allocator, PagingType::Paging4KB4Level);
+    let pt = X64PageTable::new(page_allocator.clone(), PagingType::Paging4KB4Level);
 
     assert!(pt.is_ok());
     let pt = pt.unwrap();
@@ -770,7 +770,7 @@ fn test_query_memory_address_zero_size() {
 
     let page_allocator = Box::new(TestPageAllocator::new(max_pages, PagingType::Paging4KB4Level));
 
-    let pt = X64PageTable::new(page_allocator, PagingType::Paging4KB4Level);
+    let pt = X64PageTable::new(page_allocator.clone(), PagingType::Paging4KB4Level);
 
     assert!(pt.is_ok());
     let pt = pt.unwrap();
@@ -803,7 +803,7 @@ fn test_remap_memory_address_simple() {
         // println!("num pages: {} address: {:x} size: {:x}", num_pages, address, size);
 
         let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
-        let pt = X64PageTable::new(page_allocator, paging_type);
+        let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
         assert!(pt.is_ok());
         let mut pt = pt.unwrap();
@@ -840,7 +840,7 @@ fn test_remap_memory_address_0_to_ffff_ffff() {
             // println!("num pages: {} address: {:x} size: {:x}", num_pages, address, size);
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
-            let pt = X64PageTable::new(page_allocator, paging_type);
+            let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -891,7 +891,7 @@ fn test_remap_memory_address_single_page_from_0_to_ffff_ffff() {
             // println!("num pages: {} address: {:x} size: {:x}", num_pages, address, size);
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
-            let pt = X64PageTable::new(page_allocator, paging_type);
+            let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -940,7 +940,7 @@ fn test_remap_memory_address_multiple_page_from_0_to_ffff_ffff() {
             // println!("num pages: {} address: {:x} size: {:x}", num_pages, address, size);
 
             let page_allocator = Box::new(TestPageAllocator::new(num_pages, paging_type));
-            let pt = X64PageTable::new(page_allocator, paging_type);
+            let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
             assert!(pt.is_ok());
             let mut pt = pt.unwrap();
@@ -977,7 +977,7 @@ fn test_remap_memory_address_unaligned() {
 
         let page_allocator = Box::new(TestPageAllocator::new(max_pages, paging_type));
 
-        let pt = X64PageTable::new(page_allocator, paging_type);
+        let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
         assert!(pt.is_ok());
         let mut pt = pt.unwrap();
@@ -1009,7 +1009,7 @@ fn test_remap_memory_address_zero_size() {
 
         let page_allocator = Box::new(TestPageAllocator::new(max_pages, paging_type));
 
-        let pt = X64PageTable::new(page_allocator, paging_type);
+        let pt = X64PageTable::new(page_allocator.clone(), paging_type);
 
         assert!(pt.is_ok());
         let mut pt = pt.unwrap();


### PR DESCRIPTION
- Fix missing clone() method in the tests. Needed to revalidate the paging after the test
- Fix module exports(which are configured out when trying to used this crate from another crate tests)
- Minor clippy fixes