### PR TITLE
publish-release.yml: Update trigger to on release publish

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,27 +10,12 @@
 name: Publish Release
 
 on:
-  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
-  validate_branch:
-    name: Validate Branch
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Validate Branch
-        run: |
-          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
-              echo "This workflow can only be run on the main branch."
-              exit 1
-          fi
-    
   release:
     name: Release
-    needs: validate_branch
     uses: pop-project/uefi-dxe-core/.github/workflows/ReleaseWorkflow.yml@main
     secrets: inherit
     permissions:


### PR DESCRIPTION
## Description

Updates the trigger for running the release crates workflow to be when a release is published to github.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

After publishing a release, wait for the workflow to finish and publish the specified pull request.
