### PR TITLE
Fixing bugs where the registers are checked against the incorrect EL counterpart

### DIFF
--- a/src/aarch64/reg.rs
+++ b/src/aarch64/reg.rs
@@ -363,7 +363,7 @@ pub fn is_this_page_table_active(page_table_base: PhysicalAddress) -> bool {
         match _current_el {
             2 => asm!("mrs {}, ttbr0_el2", out(reg) _ttbr0),
             1 => asm!("mrs {}, ttbr0_el1", out(reg) _ttbr0),
-            invalid_el  => panic!("Invalid current EL {}", invalid_el),
+            invalid_el => panic!("Invalid current EL {}", invalid_el),
         }
     }
 


### PR DESCRIPTION
## Description

The original code will blindly check the EL1 version of the registers to evaluate whether the MMU is enabled or not, or what TTBR0 is being set to.

This change updates the logic to check the EL level and read the register accordingly.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on QEMU SBSA system.

## Integration Instructions

N/A
