### PR TITLE
Change GitHub org name from pop-project to OpenDevicePartnership

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,5 +7,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📃 Documentation
-    url: https://pop-project.github.io/paging/
+    url: https://OpenDevicePartnership.github.io/paging/
     about: Goals, principles, repo layout, build instructions, and more.

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -19,5 +19,5 @@ on:
 jobs:
   ci_workflow:
     name: Run
-    uses: pop-project/uefi-dxe-core/.github/workflows/CiWorkflow.yml@main
+    uses: OpenDevicePartnership/uefi-dxe-core/.github/workflows/CiWorkflow.yml@main
     secrets: inherit

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -29,4 +29,4 @@ jobs:
       contents: read
       pull-requests: write
 
-    uses: pop-project/uefi-dxe-core/.github/workflows/Labeler.yml@main
+    uses: OpenDevicePartnership/uefi-dxe-core/.github/workflows/Labeler.yml@main

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -22,5 +22,5 @@ jobs:
     permissions:
       issues: write
 
-    uses: pop-project/uefi-dxe-core/.github/workflows/LabelSyncer.yml@main
+    uses: OpenDevicePartnership/uefi-dxe-core/.github/workflows/LabelSyncer.yml@main
     secrets: inherit

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   release:
     name: Release
-    uses: pop-project/uefi-dxe-core/.github/workflows/ReleaseWorkflow.yml@main
+    uses: OpenDevicePartnership/uefi-dxe-core/.github/workflows/ReleaseWorkflow.yml@main
     secrets: inherit
     permissions:
       contents: write

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ publish = ["UefiRust"]
 edition = "2021"
 license = "BSD-2-Clause-Patent"
 description = "Paging library for AArch64 & X64 architectures"
-repository = "https://github.com/pop-project/paging"
+repository = "https://github.com/OpenDevicePartnership/paging"
 keywords = ["paging"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
## Description

The org name has switched to OpenDevicePartnership so all references to the previous org name are updated.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Verified new URLs.
- Note: "pop-project" will redirect to "OpenDevicePartnership" so the old URLs will still work for now.
  - https://github.com/pop-project will return 404 until/if it is claimed by someone else.

## Integration Instructions

- N/A