### PR TITLE
Use uefi_sdk version 2*

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ features = ["doc"]
 bitfield-struct = "0.9.2"
 bitflags = "2.6.0"
 log = { version = "=0.4.22", default-features = false }
-uefi_sdk = { version = "1.0.1" }
+uefi_sdk = { version = "2" }
 mu_pi = { version = "5" }
 
 [features]


### PR DESCRIPTION
## Description

Update UEFI_SDK to version 2 to be consistent with other crates.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Local tests with `cargo make test`

## Integration Instructions

N/A
