### PR TITLE
Clone shadow entry to avoid direct modifcation of page table in update_shadow_fields

### DIFF
--- a/src/aarch64/pagetablestore.rs
+++ b/src/aarch64/pagetablestore.rs
@@ -106,7 +106,7 @@ impl AArch64PageTableEntry {
 
     pub fn update_shadow_fields(&mut self, attributes: MemoryAttributes, pa: PhysicalAddress) -> u64 {
         let entry = unsafe { get_entry::<AArch64Descriptor>(self.page_base, self.index) };
-        let mut shadow_entry = *entry;
+        let mut shadow_entry = entry.clone();
         match shadow_entry.update_fields(attributes, pa) {
             Ok(_) => {}
             Err(_) => panic!("Failed to update shadow table entry"),


### PR DESCRIPTION
## Description

Present implementation of update_shadow_fields directly modifies the entry in the page table as returned by get_entry(). This change clones the entry so that modifications to it do not write directly into the page table but instead are written to the clone. This prevents the update_shadow_fields() routine from modifying the live entry. 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booted to os loader without observing any unexpected behavior. 

## Integration Instructions

N/A
