### PR TITLE
cspell.yml: Rework config

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -10,25 +10,27 @@ version: "0.2"
 language: en
 dictionaries:
   - "companies"
-  - "softwareTerms"
+  - "cpp"
+  - "cpp-legacy"
+  - "java"
+  - "makefile"
+  - "python"
   - "rust"
+  - "softwareTerms"
 ignorePaths:
   - "**/target/**"
   - "**/book/**"
   - "**/*.asm"
   - "Makefile.toml"
+ignoreRegExpList: ["/0x[0-9a-fA-F]+/"]
 minWordLength: 5
 caseSensitive: false
 allowCompoundWords: true
 words:
-  - aarch
-  - mtrr
-  - uncacheable
-  - sctlr
-  - xffff
-  - structs
-  - kbyte
-  - efiapi
-  - vmalle
-  - nshst
   - civac
+  - kbyte
+  - mtrrs
+  - nshst
+  - sctlr
+  - vmalle
+  - xffff


### PR DESCRIPTION
## Description

- Ignore hexadecimal values rarely interpreted as strings.
- Add more common dictionaries to reduce false positives.
- Cleanup words no longer needed due to the new dictionaries being used.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Run cspell locally

## Integration Instructions

- N/A