### PR TITLE
Convert write_bytes to asm

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -32,6 +32,8 @@ words:
   - mfence
   - mtrrs
   - nshst
+  - qwords
   - sctlr
+  - stosq
   - vmalle
   - xffff


### PR DESCRIPTION
## Description

To ensure that the Rust compiler does not optimize out any zeroing of pages, use volatile writes. Unfortunately the volatile version of write_bytes is only on the nightly channel, so this has to convert to asm in order to achieve performance on non-optimized builds

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booted to Windows on Q35 and SBSA.

## Integration Instructions

N/A.