### PR TITLE
Remove the external API for predicting page count

### DIFF
--- a/src/aarch64/paging.rs
+++ b/src/aarch64/paging.rs
@@ -884,10 +884,6 @@ impl<A: PageAllocator> PageTable for AArch64PageTable<A> {
         log::info!("{}", "-".repeat(130));
         self.dump_page_tables_internal(start_va, end_va, self.highest_page_level, self.base)
     }
-
-    fn get_page_table_pages_for_size(&self, _address: u64, _size: u64) -> PtResult<u64> {
-        num_page_tables_required(_address, _size, self.paging_type)
-    }
 }
 
 fn find_num_entries(start_offset: u64, end_offset: u64, num_parent_level_entries: u64) -> u64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,15 +170,6 @@ pub trait PageTable {
     /// * `address` - The memory address to map.
     /// * `size` - The memory size to map.
     fn dump_page_tables(&self, address: u64, size: u64);
-
-    /// Function to get the number of page table pages required for the new address and size.
-    ///
-    /// ## Arguments
-    /// * `size` - The memory size to map.
-    ///
-    /// ## Returns
-    /// Returns the number of page table pages required for the new address and size.
-    fn get_page_table_pages_for_size(&self, address: u64, size: u64) -> PtResult<u64>;
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/x64/paging.rs
+++ b/src/x64/paging.rs
@@ -833,10 +833,6 @@ impl<A: PageAllocator> PageTable for X64PageTable<A> {
         self.dump_page_tables_internal(start_va, end_va, self.highest_page_level, self.base);
         log::info!("{}", "-".repeat(132));
     }
-
-    fn get_page_table_pages_for_size(&self, address: u64, size: u64) -> PtResult<u64> {
-        num_page_tables_required(address, size, self.paging_type)
-    }
 }
 
 /// Given the [start, end offset] at the current level from the [start, end VA],


### PR DESCRIPTION
## Description

With the self-map it should no longer be necessary for callers to predict the number of pages needed and doing so leads to over-allocation as the prediction logic is not considering existing mappings. This change removes the external use of the functionality, but retains the internal code for tests.

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Unit tests

## Integration Instructions

Consumers must remove use of `get_page_table_pages_for_size`.
