### PR TITLE
[REBASE & FF] Add InconsistentMappingAcrossRange Error Code

### DIFF
--- a/src/aarch64/paging.rs
+++ b/src/aarch64/paging.rs
@@ -4,8 +4,8 @@ use super::{
     structs::*,
 };
 use crate::{
-    page_allocator::PageAllocator, MemoryAttributes, PageTable, PagingType, PtError, PtResult, SIZE_16TB, SIZE_1TB,
-    SIZE_256TB, SIZE_4GB, SIZE_4TB, SIZE_64GB,
+    page_allocator::PageAllocator, MemoryAttributes, PageTable, PagingType, PtError, PtResult, RangeMappingState,
+    SIZE_16TB, SIZE_1TB, SIZE_256TB, SIZE_4GB, SIZE_4TB, SIZE_64GB,
 };
 
 const MAX_VA_BITS: u64 = 48;
@@ -468,7 +468,7 @@ impl<A: PageAllocator> AArch64PageTable<A> {
         end_va: VirtualAddress,
         level: PageLevel,
         base: PhysicalAddress,
-        prev_attributes: &mut MemoryAttributes,
+        prev_attributes: &mut RangeMappingState,
     ) -> PtResult<MemoryAttributes> {
         let mut va = start_va;
 
@@ -483,19 +483,31 @@ impl<A: PageAllocator> AArch64PageTable<A> {
         let mut entries = table.into_iter().peekable();
         while let Some(entry) = entries.next() {
             if !entry.is_valid() {
-                return Err(PtError::NoMapping);
+                // if we found an entry that is not present after finding entries that were already mapped,
+                // we fail this with InconsistentMappingAcrossRange. If we have set found any region yet, mark
+                // this as an unmapped region and continue
+                match prev_attributes {
+                    RangeMappingState::Uninitialized => *prev_attributes = RangeMappingState::Unmapped,
+                    RangeMappingState::Mapped(_) => return Err(PtError::InconsistentMappingAcrossRange),
+                    RangeMappingState::Unmapped => {}
+                }
+                continue;
             }
 
             if entry.is_block_entry() {
                 // Given memory range can span multiple page table entries, in such
                 // scenario, the expectation is all entries should have same attributes.
                 let current_attributes = entry.get_attributes();
-                if (*prev_attributes).is_empty() {
-                    *prev_attributes = current_attributes;
-                }
-
-                if *prev_attributes != current_attributes {
-                    return Err(PtError::IncompatibleMemoryAttributes);
+                match prev_attributes {
+                    RangeMappingState::Uninitialized => {
+                        *prev_attributes = RangeMappingState::Mapped(current_attributes)
+                    }
+                    RangeMappingState::Unmapped => return Err(PtError::InconsistentMappingAcrossRange),
+                    RangeMappingState::Mapped(attrs) => {
+                        if *attrs != current_attributes {
+                            return Err(PtError::IncompatibleMemoryAttributes);
+                        }
+                    }
                 }
             } else {
                 let next_base = entry.get_canonical_page_table_base();
@@ -511,13 +523,19 @@ impl<A: PageAllocator> AArch64PageTable<A> {
                 // end of next level va. It will be minimum of next va and end va
                 let next_level_end_va = VirtualAddress::min(curr_va_ceil, end_va);
 
-                self.query_memory_region_internal(
+                // if we got an error besides NoMapping, we should return that up the stack, we've failed entirely
+                // no mapping may be the case, but we need to continue walking down the page tables to see if we
+                // find any mapped regions and need to fail the query with InconsistentMappingAcrossRange
+                match self.query_memory_region_internal(
                     next_level_start_va,
                     next_level_end_va,
                     (level as u64 - 1).into(),
                     next_base,
                     prev_attributes,
-                )?;
+                ) {
+                    Ok(_) | Err(PtError::NoMapping) => {}
+                    Err(e) => return Err(e),
+                }
             }
 
             // only calculate the next VA if there is another entry in the table we are processing
@@ -527,7 +545,12 @@ impl<A: PageAllocator> AArch64PageTable<A> {
             }
         }
 
-        Ok(*prev_attributes)
+        match prev_attributes {
+            // entire region was mapped consistently
+            RangeMappingState::Mapped(attrs) => Ok(*attrs),
+            // we only found unmapped regions, so report the entire region is unmapped
+            _ => Err(PtError::NoMapping),
+        }
     }
 
     /// Splits a large page into the next page level pages. This done by
@@ -854,7 +877,7 @@ impl<A: PageAllocator> PageTable for AArch64PageTable<A> {
         let end_va = address + size - 1;
 
         // make sure the memory region has same attributes set
-        let mut prev_attributes = MemoryAttributes::empty();
+        let mut prev_attributes = RangeMappingState::Uninitialized;
         self.query_memory_region_internal(start_va, end_va, self.highest_page_level, self.base, &mut prev_attributes)?;
 
         self.remap_memory_region_internal(start_va, end_va, self.highest_page_level, self.base, attributes)
@@ -868,7 +891,7 @@ impl<A: PageAllocator> PageTable for AArch64PageTable<A> {
         let start_va = address;
         let end_va = address + size - 1;
 
-        let mut prev_attributes = MemoryAttributes::empty();
+        let mut prev_attributes = RangeMappingState::Uninitialized;
         self.query_memory_region_internal(start_va, end_va, self.highest_page_level, self.base, &mut prev_attributes)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,13 @@ pub enum PtError {
     InconsistentMappingAcrossRange,
 }
 
+#[derive(Debug, PartialEq)]
+enum RangeMappingState {
+    Uninitialized,
+    Mapped(MemoryAttributes),
+    Unmapped,
+}
+
 // NOTE: On X64, Memory caching attributes are handled via MTRRs. On AArch64,
 // paging handles both memory access and caching attributes. Hence we defined
 // both of them here.

--- a/src/tests/aarch64_paging_tests.rs
+++ b/src/tests/aarch64_paging_tests.rs
@@ -778,6 +778,99 @@ fn test_query_memory_address_zero_size() {
     assert_eq!(res, Err(PtError::InvalidMemoryRange));
 }
 
+#[test]
+fn test_query_memory_address_inconsistent_mappings() {
+    struct TestConfig {
+        paging_type: PagingType,
+        address: u64,
+        size: u64,
+    }
+
+    let test_configs = [TestConfig { paging_type: PagingType::AArch64PageTable4KB, address: 0x1000, size: 0x3000 }];
+
+    for test_config in test_configs {
+        let TestConfig { size, address, paging_type } = test_config;
+
+        let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x4;
+
+        let page_allocator = TestPageAllocator::new(num_pages, paging_type);
+        let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
+
+        assert!(pt.is_ok());
+        let mut pt = pt.unwrap();
+
+        // Map the first part of the range
+        let attributes = MemoryAttributes::ReadOnly | MemoryAttributes::Writeback;
+        let res = pt.map_memory_region(address, FRAME_SIZE_4KB, attributes);
+        assert!(res.is_ok());
+
+        // Map the last part of the range
+        let res = pt.map_memory_region(address + 2 * FRAME_SIZE_4KB, FRAME_SIZE_4KB, attributes);
+        assert!(res.is_ok());
+
+        // Query the entire range, should return InconsistentMappingAcrossRange error
+        let res = pt.query_memory_region(address, size);
+        assert!(res.is_err());
+        assert_eq!(res, Err(PtError::InconsistentMappingAcrossRange));
+    }
+}
+
+#[test]
+fn test_query_memory_address_inconsistent_mappings_across_2mb_boundary() {
+    struct TestConfig {
+        paging_type: PagingType,
+        address: u64,
+        size: u64,
+    }
+
+    let test_configs = [TestConfig { paging_type: PagingType::AArch64PageTable4KB, address: 0x0, size: 0x400000 }];
+
+    for test_config in test_configs {
+        let TestConfig { size, address, paging_type } = test_config;
+
+        let page_allocator = TestPageAllocator::new(0x1000, paging_type);
+        let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
+
+        assert!(pt.is_ok());
+        let mut pt = pt.unwrap();
+
+        // Map the first 2MB, but not the second 2MB, map in 1MB chunks so that all PTEs are mapped
+        let attributes = MemoryAttributes::ReadOnly | MemoryAttributes::Writeback;
+        let res = pt.map_memory_region(address, 0x100000, attributes);
+        assert!(res.is_ok());
+        let res = pt.map_memory_region(address + 0x100000, 0x100000, attributes);
+        assert!(res.is_ok());
+        // now unmap so we have valid entries down to PTE, but invalid there
+        // let res = pt.unmap_memory_region(address, 0x200000);
+        // assert!(res.is_ok());
+        let res = pt.map_memory_region(address + 0x200000, 0x100000, attributes);
+        assert!(res.is_ok());
+        let res = pt.map_memory_region(address + 0x300000, 0x100000, attributes);
+        assert!(res.is_ok());
+        let res = pt.unmap_memory_region(address + 0x200000, 0x200000);
+        assert!(res.is_ok());
+
+        // Query the entire range, should return InconsistentMappingsAcrossRange error
+        let res = pt.query_memory_region(address, size);
+        assert!(res.is_err());
+        assert_eq!(res, Err(PtError::InconsistentMappingAcrossRange));
+
+        // Now unmap the first 2MB and map the second 2MB
+        let res = pt.unmap_memory_region(address, 0x200000);
+        assert!(res.is_ok());
+
+        let res = pt.map_memory_region(address + 0x200000, 0x100000, attributes);
+        assert!(res.is_ok());
+        let res = pt.map_memory_region(address + 0x300000, 0x100000, attributes);
+        assert!(res.is_ok());
+
+        // Query the entire range, should return InconsistentMappingsAcrossRange error
+        let res = pt.query_memory_region(address, size);
+        assert!(res.is_err());
+        assert_eq!(res, Err(PtError::InconsistentMappingAcrossRange));
+    }
+}
+
 // Memory remap tests
 #[test]
 fn test_remap_memory_address_simple() {


### PR DESCRIPTION
## Description

This PR adds two commits:

Return Error When Attempting to Map Already Mapped Page
--
The current code asserts when map_memory_region_internal attempts to map a page that is already mapped. This leads to an unuseful state for consumers, who don't know what code led to this failure.

This patch updates the code to return an error so that the caller can handle it and log/assert at that level.

It also introduces a new error code to return from this crate when a range passed in is inconsistently mapped, i.e. some entries are mapped and some are unmapped.

Update query_memory_region to Return New Error Code
--
Today query_memory_region returns NoMapping when any entry in the range is unmapped. However, this is not sufficient for callers, who may use query_memory_region to decide whether to map a region or not, which is only valid if the entire region is unmapped.

This patch leverages the new InconsistentMappingAcrossRange error code to indicate that the given range has some entries that are mapped and some that are unmapped.

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested booting Q35, SBSA, and a physical Intel platform to Windows.

## Integration Instructions

This is marked as a breaking change because it adds a new error code that may be returned from the paging APIs, so callers need to handle this error.
