### PR TITLE
Self-Map: Simplify zeroing of newly allocated pages

### DIFF
--- a/src/aarch64/structs.rs
+++ b/src/aarch64/structs.rs
@@ -24,9 +24,9 @@ pub(crate) const INDEX_MASK: u64 = 0x1FF;
 
 const PAGE_MAP_ENTRY_PAGE_TABLE_BASE_ADDRESS_SHIFT: u64 = 12u64; // lower 12 bits for alignment
 
-// The zero VA used to create a VA range to zero pages before putting them in the page table. These addresses are
-// calculated as the first VA in the penultimate index in the top level page table.
-pub(crate) const ZERO_VA_4_LEVEL: u64 = 0xFF00_0000_0000;
+// The following definition is the VA for the penultimate index in the top level
+// page table, used for zeroing newly allocated pages.
+pub(crate) const ZERO_VA_4_LEVEL: u64 = 0xFFFF_FFFF_E000;
 
 // The self map index is used to map the page table itself. For simplicity, we choose the final index of the top
 // level page table. This has a potential conflict with identity mapping, as the final index of the top level page table

--- a/src/tests/aarch64_paging_tests.rs
+++ b/src/tests/aarch64_paging_tests.rs
@@ -89,7 +89,7 @@ fn test_map_memory_address_simple() {
     for test_config in test_configs {
         let TestConfig { size, address, paging_type } = test_config;
 
-        let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x3;
+        let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
         let page_allocator = TestPageAllocator::new(num_pages, paging_type);
 
@@ -121,7 +121,7 @@ fn test_map_memory_address_not_so_simple() {
     for test_config in test_configs {
         let TestConfig { size, address, paging_type } = test_config;
 
-        let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x3;
+        let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
         let page_allocator = TestPageAllocator::new(num_pages, paging_type);
 
@@ -154,7 +154,7 @@ fn test_map_memory_address_0_to_ffff_ffff() {
         let TestConfig { mut size, address, paging_type } = test_config;
 
         while size < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x3;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
 
@@ -199,7 +199,7 @@ fn test_map_memory_address_single_page_from_0_to_ffff_ffff() {
     for test_config in test_configs {
         let TestConfig { size, mut address, address_increment, paging_type } = test_config;
         while address < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x3;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
 
@@ -240,7 +240,7 @@ fn test_map_memory_address_multiple_page_from_0_to_ffff_ffff() {
         let TestConfig { size, mut address, address_increment, paging_type } = test_config;
 
         while address < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x3;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
 
@@ -400,7 +400,7 @@ fn test_unmap_memory_address_simple() {
     for test_config in test_configs {
         let TestConfig { size, address, paging_type } = test_config;
 
-        let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x3;
+        let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
         let page_allocator = TestPageAllocator::new(num_pages, paging_type);
 
@@ -433,7 +433,7 @@ fn test_unmap_memory_address_0_to_ffff_ffff() {
         let TestConfig { mut size, address, paging_type } = test_config;
 
         while size < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x3;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
 
@@ -475,7 +475,7 @@ fn test_unmap_memory_address_single_page_from_0_to_ffff_ffff() {
         let TestConfig { size, mut address, paging_type, address_increment } = test_config;
 
         while address < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x3;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
 
@@ -515,7 +515,7 @@ fn test_unmap_memory_address_multiple_page_from_0_to_ffff_ffff() {
         let TestConfig { size, mut address, paging_type, address_increment } = test_config;
 
         while address < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x3;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
 
@@ -609,7 +609,7 @@ fn test_query_memory_address_simple() {
     for test_config in test_configs {
         let TestConfig { size, address, paging_type } = test_config;
 
-        let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x3;
+        let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
         let page_allocator = TestPageAllocator::new(num_pages, paging_type);
 
@@ -642,7 +642,7 @@ fn test_query_memory_address_0_to_ffff_ffff() {
     for test_config in test_configs {
         let TestConfig { mut size, address, paging_type } = test_config;
         while size < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x3;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
 
@@ -682,7 +682,7 @@ fn test_query_memory_address_single_page_from_0_to_ffff_ffff() {
     for test_config in test_configs {
         let TestConfig { size, mut address, paging_type, step } = test_config;
         while address < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x3;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
 
@@ -721,7 +721,7 @@ fn test_query_memory_address_multiple_page_from_0_to_ffff_ffff() {
     for test_config in test_configs {
         let TestConfig { size, mut address, paging_type, step } = test_config;
         while address < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x3;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
 
@@ -889,7 +889,7 @@ fn test_remap_memory_address_simple() {
     for test_config in test_configs {
         let TestConfig { size, address, paging_type } = test_config;
 
-        let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x3;
+        let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
         let page_allocator = TestPageAllocator::new(num_pages, paging_type);
 
@@ -923,7 +923,7 @@ fn test_remap_memory_address_0_to_ffff_ffff() {
         let TestConfig { mut size, address, paging_type } = test_config;
 
         while size < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x3;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
 
@@ -966,7 +966,7 @@ fn test_remap_memory_address_single_page_from_0_to_ffff_ffff() {
         let TestConfig { size, mut address, address_increment, paging_type } = test_config;
 
         while address < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x3;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
 
@@ -1007,7 +1007,7 @@ fn test_remap_memory_address_multiple_page_from_0_to_ffff_ffff() {
         let TestConfig { size, mut address, address_increment, paging_type } = test_config;
 
         while address < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x3;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
 
@@ -1103,7 +1103,7 @@ fn test_from_existing_page_table() {
     for test_config in test_configs {
         let TestConfig { size, address, paging_type } = test_config;
 
-        let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x3;
+        let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
         let page_allocator = TestPageAllocator::new(num_pages, paging_type);
 
@@ -1142,7 +1142,7 @@ fn test_dump_page_tables() {
     for test_config in test_configs {
         let TestConfig { size, address, paging_type } = test_config;
 
-        let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x3;
+        let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
         let page_allocator = TestPageAllocator::new(num_pages, paging_type);
         let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
@@ -1223,8 +1223,7 @@ fn test_large_page_splitting() {
     for test_config in test_configs {
         let TestConfig { paging_type, mapped_range, split_range, page_increase } = test_config;
         for action in [TestAction::Unmap, TestAction::Remap] {
-            let num_pages =
-                num_page_tables_required(mapped_range.address, mapped_range.size, paging_type).unwrap() + 0x3;
+            let num_pages = num_page_tables_required(mapped_range.address, mapped_range.size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages + page_increase, paging_type);
             let pt = AArch64PageTable::new(page_allocator.clone(), paging_type);
@@ -1295,19 +1294,7 @@ fn test_self_map() {
 
         // now we should see the zero VA and the self map entries in the base page table
         let zero_va_top_level = root + ZERO_VA_INDEX * size_of::<AArch64Descriptor>() as u64;
-        assert!(unsafe { *(zero_va_top_level as *const u64) != 0 });
-
-        let zero_va_pdp_level = unsafe { *(zero_va_top_level as *const u64) & !0xFFF };
-        assert!(unsafe { *(zero_va_pdp_level as *const u64) != 0 });
-
-        let zero_va_pd_level = unsafe { *(zero_va_pdp_level as *const u64) & !0xFFF };
-        assert!(unsafe { *(zero_va_pd_level as *const u64) != 0 });
-
-        let zero_va_pt_level = unsafe { *(zero_va_pd_level as *const u64) & !0xFFF };
-        assert!(unsafe { *(zero_va_pt_level as *const u64) != 0 });
-
-        let zero_va_pa = unsafe { *(zero_va_pt_level as *const u64) & !0xFFF };
-        assert!(zero_va_pa == 0);
+        assert!(unsafe { *(zero_va_top_level as *const u64) == 0 });
 
         let self_map_top_level = root + SELF_MAP_INDEX * size_of::<AArch64Descriptor>() as u64;
         assert_eq!((unsafe { *(self_map_top_level as *const u64) } & !0xFFF), root);

--- a/src/tests/aarch64_test_page_allocator.rs
+++ b/src/tests/aarch64_test_page_allocator.rs
@@ -109,24 +109,21 @@ impl TestPageAllocator {
         let page = self.get_page(*page_index).unwrap();
         let mut va = start_va;
         for index in start_index..=end_index {
-            let page_base = unsafe {
-                // this is a little weird, the 0th page is allocated as the root, then the next three pages are
-                // allocated to support the zero VA range, which we don't validate here (a separate test validates)
-                match page_index {
-                    0 => self.get_memory_base().add((PAGE_SIZE as usize) * (*page_index as usize + 4)) as u64,
-                    _ => self.get_memory_base().add((PAGE_SIZE as usize) * (*page_index as usize + 1)) as u64,
-                }
-            };
-            let leaf =
-                unsafe { self.validate_page_entry(page.add(index as usize), va.into(), page_base, level, attributes) };
+            let leaf: bool;
+            unsafe {
+                // hex_dump(page.add(index as usize) as *const u8, 8);
+                leaf = self.validate_page_entry(
+                    page.add(index as usize),
+                    va.into(),
+                    self.get_memory_base().add((PAGE_SIZE as usize) * (*page_index as usize + 1)) as u64,
+                    level,
+                    attributes,
+                );
 
-            // We only consume further pages from PageAllocator memory
-            // for page tables higher than PT type
-            if !leaf {
-                // skip over the zero VA pages
-                match page_index {
-                    0 => *page_index += 4,
-                    _ => *page_index += 1,
+                // We only consume further pages from PageAllocator memory
+                // for page tables higher than PT type
+                if !leaf {
+                    *page_index += 1;
                 }
             }
 

--- a/src/tests/x64_paging_tests.rs
+++ b/src/tests/x64_paging_tests.rs
@@ -116,7 +116,7 @@ fn test_map_memory_address_simple() {
     for test_config in test_configs {
         let TestConfig { size, address, paging_type } = test_config;
 
-        let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x4;
+        let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
         let page_allocator = TestPageAllocator::new(num_pages, paging_type);
         let pt = X64PageTable::new(page_allocator.clone(), paging_type);
@@ -152,7 +152,7 @@ fn test_map_memory_address_0_to_ffff_ffff() {
         let TestConfig { mut size, address, paging_type } = test_config;
 
         while size < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x4;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
             let pt = X64PageTable::new(page_allocator.clone(), paging_type);
@@ -202,7 +202,7 @@ fn test_map_memory_address_single_page_from_0_to_ffff_ffff() {
     for test_config in test_configs {
         let TestConfig { size, mut address, address_increment, paging_type } = test_config;
         while address < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x4;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
             let pt = X64PageTable::new(page_allocator.clone(), paging_type);
@@ -250,7 +250,7 @@ fn test_map_memory_address_multiple_page_from_0_to_ffff_ffff() {
         let TestConfig { size, mut address, address_increment, paging_type } = test_config;
 
         while address < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x4;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
             let pt = X64PageTable::new(page_allocator.clone(), paging_type);
@@ -382,7 +382,7 @@ fn test_unmap_memory_address_simple() {
     for test_config in test_configs {
         let TestConfig { size, address, paging_type } = test_config;
 
-        let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x4;
+        let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
         let page_allocator = TestPageAllocator::new(num_pages, paging_type);
         let pt = X64PageTable::new(page_allocator.clone(), paging_type);
@@ -417,7 +417,7 @@ fn test_unmap_memory_address_0_to_ffff_ffff() {
         let TestConfig { mut size, address, paging_type } = test_config;
 
         while size < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x4;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
             let pt = X64PageTable::new(page_allocator.clone(), paging_type);
@@ -466,7 +466,7 @@ fn test_unmap_memory_address_single_page_from_0_to_ffff_ffff() {
         let TestConfig { size, mut address, paging_type, address_increment } = test_config;
 
         while address < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x4;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
             let pt = X64PageTable::new(page_allocator.clone(), paging_type);
@@ -513,7 +513,7 @@ fn test_unmap_memory_address_multiple_page_from_0_to_ffff_ffff() {
         let TestConfig { size, mut address, paging_type, address_increment } = test_config;
 
         while address < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x4;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
             let pt = X64PageTable::new(page_allocator.clone(), paging_type);
@@ -609,7 +609,7 @@ fn test_query_memory_address_simple() {
     for test_config in test_configs {
         let TestConfig { size, address, paging_type } = test_config;
 
-        let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x4;
+        let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
         let page_allocator = TestPageAllocator::new(num_pages, paging_type);
         let pt = X64PageTable::new(page_allocator.clone(), paging_type);
@@ -644,7 +644,7 @@ fn test_query_memory_address_0_to_ffff_ffff() {
     for test_config in test_configs {
         let TestConfig { mut size, address, paging_type } = test_config;
         while size < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x4;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
             let pt = X64PageTable::new(page_allocator.clone(), paging_type);
@@ -682,7 +682,7 @@ fn test_query_memory_address_single_page_from_0_to_ffff_ffff() {
     for test_config in test_configs {
         let TestConfig { size, mut address, paging_type, step } = test_config;
         while address < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x4;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
             let pt = X64PageTable::new(page_allocator.clone(), paging_type);
@@ -729,7 +729,7 @@ fn test_query_memory_address_multiple_page_from_0_to_ffff_ffff() {
     for test_config in test_configs {
         let TestConfig { size, mut address, paging_type, step } = test_config;
         while address < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x4;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
             let pt = X64PageTable::new(page_allocator.clone(), paging_type);
@@ -802,7 +802,7 @@ fn test_query_memory_address_inconsistent_mappings() {
     for test_config in test_configs {
         let TestConfig { size, address, paging_type } = test_config;
 
-        let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x4;
+        let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
         let page_allocator = TestPageAllocator::new(num_pages, paging_type);
         let pt = X64PageTable::new(page_allocator.clone(), paging_type);
@@ -902,7 +902,7 @@ fn test_remap_memory_address_simple() {
     for test_config in test_configs {
         let TestConfig { size, address, paging_type } = test_config;
 
-        let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x4;
+        let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
         let page_allocator = TestPageAllocator::new(num_pages, paging_type);
         let pt = X64PageTable::new(page_allocator.clone(), paging_type);
@@ -938,7 +938,7 @@ fn test_remap_memory_address_0_to_ffff_ffff() {
         let TestConfig { mut size, address, paging_type } = test_config;
 
         while size < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x4;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
             let pt = X64PageTable::new(page_allocator.clone(), paging_type);
@@ -988,7 +988,7 @@ fn test_remap_memory_address_single_page_from_0_to_ffff_ffff() {
         let TestConfig { size, mut address, address_increment, paging_type } = test_config;
 
         while address < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x4;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
             let pt = X64PageTable::new(page_allocator.clone(), paging_type);
@@ -1036,7 +1036,7 @@ fn test_remap_memory_address_multiple_page_from_0_to_ffff_ffff() {
         let TestConfig { size, mut address, address_increment, paging_type } = test_config;
 
         while address < 0xffff_ffff {
-            let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x4;
+            let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages, paging_type);
             let pt = X64PageTable::new(page_allocator.clone(), paging_type);
@@ -1136,7 +1136,7 @@ fn test_from_existing_page_table() {
     for test_config in test_configs {
         let TestConfig { size, address, paging_type } = test_config;
 
-        let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x4;
+        let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
         let page_allocator = TestPageAllocator::new(num_pages, paging_type);
         let pt = X64PageTable::new(page_allocator.clone(), paging_type);
@@ -1176,7 +1176,7 @@ fn test_dump_page_tables() {
     for test_config in test_configs {
         let TestConfig { size, address, paging_type } = test_config;
 
-        let num_pages = num_page_tables_required(address, size, paging_type).unwrap() + 0x4;
+        let num_pages = num_page_tables_required(address, size, paging_type).unwrap();
 
         let page_allocator = TestPageAllocator::new(num_pages, paging_type);
         let pt = X64PageTable::new(page_allocator.clone(), paging_type);
@@ -1263,8 +1263,7 @@ fn test_large_page_splitting() {
     for test_config in test_configs {
         let TestConfig { paging_type, mapped_range, split_range, page_increase } = test_config;
         for action in [TestAction::Unmap, TestAction::Remap] {
-            let num_pages =
-                num_page_tables_required(mapped_range.address, mapped_range.size, paging_type).unwrap() + 0x4;
+            let num_pages = num_page_tables_required(mapped_range.address, mapped_range.size, paging_type).unwrap();
 
             let page_allocator = TestPageAllocator::new(num_pages + page_increase, paging_type);
             let pt = X64PageTable::new(page_allocator.clone(), paging_type);
@@ -1351,33 +1350,7 @@ fn test_self_map() {
 
         // now we should see the zero VA and the self map entries in the base page table
         let zero_va_top_level = root + ZERO_VA_INDEX * size_of::<PageTableEntry>() as u64;
-        assert!(unsafe { *(zero_va_top_level as *const u64) != 0 });
-
-        let zero_va_pdp_level = unsafe { *(zero_va_top_level as *const u64) & !0xFFF };
-        assert!(unsafe { *(zero_va_pdp_level as *const u64) != 0 });
-
-        let zero_va_pd_level = unsafe { *(zero_va_pdp_level as *const u64) & !0xFFF };
-        assert!(unsafe { *(zero_va_pd_level as *const u64) != 0 });
-
-        let zero_va_pt_level = unsafe { *(zero_va_pd_level as *const u64) & !0xFFF };
-        assert!(unsafe { *(zero_va_pt_level as *const u64) != 0 });
-
-        match paging_type {
-            PagingType::Paging4Level => {
-                // 4 level paging ends here, we expect the zero VA to be unmapped
-                let zero_va_pa = unsafe { *(zero_va_pt_level as *const u64) & !0xFFF };
-                assert!(zero_va_pa == 0);
-            }
-            PagingType::Paging5Level => {
-                // 5 level paging has another level to it, so names above aren't correct
-                let zero_va_real_pt_level = unsafe { *(zero_va_pt_level as *const u64) & !0xFFF };
-                assert!(unsafe { *(zero_va_pt_level as *const u64) != 0 });
-
-                let zero_va_pa_level = unsafe { *(zero_va_real_pt_level as *const u64) & !0xFFF };
-                assert!(zero_va_pa_level == 0);
-            }
-            _ => panic!("Invalid paging type"),
-        }
+        assert!(unsafe { *(zero_va_top_level as *const u64) == 0 });
 
         let self_map_top_level = root + SELF_MAP_INDEX * size_of::<PageTableEntry>() as u64;
         assert_eq!(unsafe { *(self_map_top_level as *const u64) } & CR3_PAGE_BASE_ADDRESS_MASK, root);

--- a/src/x64/structs.rs
+++ b/src/x64/structs.rs
@@ -16,11 +16,10 @@ const PAGE_INDEX_MASK: u64 = 0x1FF;
 pub(crate) const MAX_PA_5_LEVEL: u64 = 0xFFFD_FFFF_FFFF_FFFF;
 pub(crate) const MAX_PA_4_LEVEL: u64 = 0xFFFF_FEFF_FFFF_FFFF;
 
-// The following definitions are the zero VA for each level of the page table hierarchy. These are used to create a
-// VA range that is used to zero pages before putting them in the page table. These addresses are calculated as the
-// first VA in the penultimate index in the top level page table.
-pub(crate) const ZERO_VA_4_LEVEL: u64 = 0xFFFF_FF00_0000_0000;
-pub(crate) const ZERO_VA_5_LEVEL: u64 = 0xFFFE_0000_0000_0000;
+// The following definitions are the VA for the penultimate index in the top
+// level page table, used for zeroing newly allocated pages.
+pub(crate) const ZERO_VA_5_LEVEL: u64 = 0xFFFF_FFFF_FFFF_E000;
+pub(crate) const ZERO_VA_4_LEVEL: u64 = 0xFFFF_FFFF_FFFF_E000;
 
 // The self map index is used to map the page table itself. For simplicity, we choose the final index of the top
 // level page table. This does not conflict with any identity mapping, as the final index of the top level page table


### PR DESCRIPTION
## Description

Simplify zeroing of newly allocated pages. Instead of mapping and maintaining multiple levels of intermediate pages to zero a newly allocated page. Use zero va(updated in the PR) to zero the page by hooking the page into the top-level page table.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated in QEMU and boots to Windows Desktop. Next verify boot on hardware.

## Integration Instructions

NA