### PR TITLE
Reduce the usage of panic macro and minor code refactor

### DIFF
--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -1,7 +1,7 @@
 cfg_if::cfg_if! {
     // Do not optimize these sections. Maintainability and readability take
     // priority over everything else.
-    if #[cfg(target_arch = "aarch64")] {
+    if #[cfg(all(not(test), target_arch = "aarch64"))] {
         // Build the lib only for aarch64 when targetting aarch64-unknown-uefi
         pub(crate) mod pagetablestore;
         pub(crate) mod paging;

--- a/src/aarch64/reg.rs
+++ b/src/aarch64/reg.rs
@@ -6,7 +6,7 @@ cfg_if::cfg_if! {
         global_asm!(include_str!("replace_table_entry.asm"));
         // Use efiapi for the consistent calling convention.
         extern "efiapi" {
-            pub fn replace_live_xlat_entry(entry_ptr: u64, val: u64, addr: u64);
+            pub(crate) fn replace_live_xlat_entry(entry_ptr: u64, val: u64, addr: u64);
         }
     }
 }
@@ -17,7 +17,7 @@ pub(crate) enum CpuFlushType {
     EFiCpuFlushTypeInvalidate,
 }
 
-pub fn get_phys_addr_bits() -> u64 {
+pub(crate) fn get_phys_addr_bits() -> u64 {
     // read the id_aa64mmfr0_el1 register to get the physical address bits
     // Bits 0..3 of the id_aa64mmfr0_el1 system register encode the size of the
     // physical address space support on this CPU:
@@ -49,7 +49,7 @@ pub fn get_phys_addr_bits() -> u64 {
     (pa_bits << 2) + 32
 }
 
-pub fn get_current_el() -> u64 {
+pub(crate) fn get_current_el() -> u64 {
     // Default to EL2
     let mut _current_el: u64 = 8;
     #[cfg(not(test))]
@@ -68,7 +68,7 @@ pub fn get_current_el() -> u64 {
     }
 }
 
-pub fn set_tcr(_tcr: u64) {
+pub(crate) fn set_tcr(_tcr: u64) {
     #[cfg(not(test))]
     unsafe {
         let current_el = get_current_el();
@@ -89,7 +89,7 @@ pub fn set_tcr(_tcr: u64) {
     }
 }
 
-pub fn set_ttbr0(_ttbr0: u64) {
+pub(crate) fn set_ttbr0(_ttbr0: u64) {
     #[cfg(not(test))]
     unsafe {
         let current_el = get_current_el();
@@ -110,7 +110,7 @@ pub fn set_ttbr0(_ttbr0: u64) {
     }
 }
 
-pub fn set_mair(_mair: u64) {
+pub(crate) fn set_mair(_mair: u64) {
     #[cfg(not(test))]
     unsafe {
         let current_el = get_current_el();
@@ -131,7 +131,7 @@ pub fn set_mair(_mair: u64) {
     }
 }
 
-pub fn is_mmu_enabled() -> bool {
+pub(crate) fn is_mmu_enabled() -> bool {
     let mut _sctlr: u64 = 0;
     #[cfg(not(test))]
     unsafe {
@@ -145,7 +145,7 @@ pub fn is_mmu_enabled() -> bool {
     _sctlr & 0x1 == 1
 }
 
-pub fn enable_mmu() {
+pub(crate) fn enable_mmu() {
     #[cfg(not(test))]
     unsafe {
         let current_el = get_current_el();
@@ -176,7 +176,7 @@ pub fn enable_mmu() {
     }
 }
 
-pub fn set_stack_alignment_check(_enable: bool) {
+pub(crate) fn set_stack_alignment_check(_enable: bool) {
     #[cfg(not(test))]
     unsafe {
         let current_el = get_current_el();
@@ -200,7 +200,7 @@ pub fn set_stack_alignment_check(_enable: bool) {
     }
 }
 
-pub fn set_alignment_check(_enable: bool) {
+pub(crate) fn set_alignment_check(_enable: bool) {
     #[cfg(not(test))]
     unsafe {
         let current_el = get_current_el();
@@ -224,7 +224,7 @@ pub fn set_alignment_check(_enable: bool) {
     }
 }
 
-pub fn enable_instruction_cache() {
+pub(crate) fn enable_instruction_cache() {
     #[cfg(not(test))]
     unsafe {
         let current_el = get_current_el();
@@ -240,7 +240,7 @@ pub fn enable_instruction_cache() {
     }
 }
 
-pub fn enable_data_cache() {
+pub(crate) fn enable_data_cache() {
     #[cfg(not(test))]
     unsafe {
         let current_el = get_current_el();
@@ -256,7 +256,7 @@ pub fn enable_data_cache() {
     }
 }
 
-pub fn update_translation_table_entry(_translation_table_entry: u64, _mva: u64) {
+pub(crate) fn update_translation_table_entry(_translation_table_entry: u64, _mva: u64) {
     #[cfg(not(test))]
     unsafe {
         let current_el = get_current_el();
@@ -358,7 +358,7 @@ fn clean_and_invalidate_data_entry_by_mva(_mva: u64) {
 }
 
 // Helper function to check if this page table is active
-pub fn is_this_page_table_active(page_table_base: PhysicalAddress) -> bool {
+pub(crate) fn is_this_page_table_active(page_table_base: PhysicalAddress) -> bool {
     // Check the TTBR0 register to see if this page table matches
     // our base
     let mut _ttbr0: u64 = 0;

--- a/src/aarch64/structs.rs
+++ b/src/aarch64/structs.rs
@@ -6,11 +6,9 @@ use core::{
     ops::{Add, Sub},
 };
 
-pub(crate) const MAX_VA: u64 = 0x0000_ffff_ffff_ffff;
-
-// this is the maximum physical address that can be used in the system because of our artifical restriction to use
+// This is the maximum virtual address that can be used in the system because of our artifical restriction to use
 // the zero VA and self map index in the top level page table. This is a temporary restriction
-pub(crate) const MAX_PA: u64 = 0x0000_feff_ffff_ffff;
+pub(crate) const MAX_VA_4_LEVEL: u64 = 0x0000_FEFF_FFFF_FFFF;
 
 const LEVEL0_START_BIT: u64 = 39;
 const LEVEL1_START_BIT: u64 = 30;
@@ -106,7 +104,7 @@ impl AArch64Descriptor {
     pub fn update_fields(&mut self, attributes: MemoryAttributes, next_pa: PhysicalAddress) -> PtResult<()> {
         let next_level_table_base = next_pa.into();
         if !is_4kb_aligned(next_level_table_base) {
-            panic!("allocated page is not 4k aligned {:X}", next_level_table_base);
+            return Err(PtError::UnalignedPageBase);
         }
 
         let pfn = next_level_table_base >> PAGE_MAP_ENTRY_PAGE_TABLE_BASE_ADDRESS_SHIFT;

--- a/src/aarch64/tests/aarch64_paging_tests.rs
+++ b/src/aarch64/tests/aarch64_paging_tests.rs
@@ -6,8 +6,8 @@ use crate::PtResult;
 use crate::{
     aarch64::{
         structs::{
-            AArch64Descriptor, FOUR_LEVEL_PML4_SELF_MAP_BASE, FRAME_SIZE_4KB, MAX_VA, SELF_MAP_INDEX, ZERO_VA_4_LEVEL,
-            ZERO_VA_INDEX,
+            AArch64Descriptor, FOUR_LEVEL_PML4_SELF_MAP_BASE, FRAME_SIZE_4KB, MAX_VA_4_LEVEL, SELF_MAP_INDEX,
+            ZERO_VA_4_LEVEL, ZERO_VA_INDEX,
         },
         tests::aarch64_test_page_allocator::TestPageAllocator,
         AArch64PageTable,
@@ -418,7 +418,7 @@ fn test_map_memory_address_range_overflow() {
 
     let test_configs = [
         // VA range overflows
-        TestConfig { paging_type: PagingType::AArch64PageTable4KB, address: MAX_VA, size: MAX_VA },
+        TestConfig { paging_type: PagingType::AArch64PageTable4KB, address: MAX_VA_4_LEVEL, size: MAX_VA_4_LEVEL },
     ];
 
     for test_config in test_configs {
@@ -449,7 +449,7 @@ fn test_map_memory_address_invalid_range() {
 
     let test_configs = [
         // VA above the valid address range
-        TestConfig { paging_type: PagingType::AArch64PageTable4KB, address: MAX_VA + 1, size: FRAME_SIZE_4KB },
+        TestConfig { paging_type: PagingType::AArch64PageTable4KB, address: MAX_VA_4_LEVEL + 1, size: FRAME_SIZE_4KB },
     ];
 
     for test_config in test_configs {
@@ -1400,9 +1400,10 @@ fn test_self_map() {
         assert!(pt.is_ok());
         let pt = pt.unwrap();
 
-        // query self map base addresses
+        // we can't query PML4 self map base address(with FOUR_LEVEL_PML4_SELF_MAP_BASE VA), as that
+        // va is exclusively reserved for use by the self-map system.
         let res = pt.query_memory_region(FOUR_LEVEL_PML4_SELF_MAP_BASE, FRAME_SIZE_4KB);
-        assert!(res.is_ok());
+        assert!(res.is_err());
 
         // we can't query the zero VA because in new() it is not mapped on purpose, so we just check we mapped
         // down to the PTE level

--- a/src/x64.rs
+++ b/src/x64.rs
@@ -1,7 +1,7 @@
 cfg_if::cfg_if! {
     // Do not optimize these sections. Maintainability and readability take
     // priority over everything else.
-    if #[cfg(target_arch = "x86_64")] {
+    if #[cfg(all(not(test), target_arch = "x86_64"))] {
         // Build the lib only for x64 when targetting x86_64-unknown-uefi.
         pub(crate) mod pagetablestore;
         pub(crate) mod paging;

--- a/src/x64/reg.rs
+++ b/src/x64/reg.rs
@@ -3,7 +3,7 @@ use super::structs::CR3_PAGE_BASE_ADDRESS_MASK;
 use core::arch::asm;
 
 /// Write CR3 register. Also invalidates TLB.
-pub unsafe fn write_cr3(_value: u64) {
+pub(crate) unsafe fn write_cr3(_value: u64) {
     #[cfg(not(test))]
     {
         unsafe {
@@ -13,7 +13,7 @@ pub unsafe fn write_cr3(_value: u64) {
 }
 
 /// Read CR3 register.
-pub unsafe fn read_cr3() -> u64 {
+pub(crate) unsafe fn read_cr3() -> u64 {
     let mut _value = 0u64;
 
     #[cfg(not(test))]
@@ -28,7 +28,7 @@ pub unsafe fn read_cr3() -> u64 {
 
 /// Invalidate the TLB by reloading the CR3 register if the base is currently
 /// being used
-pub unsafe fn invalidate_tlb(base: u64) {
+pub(crate) unsafe fn invalidate_tlb(base: u64) {
     let value = base & CR3_PAGE_BASE_ADDRESS_MASK;
     if read_cr3() == value {
         write_cr3(value);

--- a/src/x64/structs.rs
+++ b/src/x64/structs.rs
@@ -11,16 +11,16 @@ pub const PAGE_SIZE: u64 = 0x1000; // 4KB
 
 const PAGE_INDEX_MASK: u64 = 0x1FF;
 
-// The following definitions are the maximum physical address for each level of the page table hierarchy. These are
+// The following definitions are the maximum virtual address for each level of the page table hierarchy. These are
 // above the range generally supported by processors, but we only care that our zero VA and self-map aren't overwritten
-pub(crate) const MAX_PA_5_LEVEL: u64 = 0xFFFD_FFFF_FFFF_FFFF;
-pub(crate) const MAX_PA_4_LEVEL: u64 = 0xFFFF_FEFF_FFFF_FFFF;
+pub(crate) const MAX_VA_5_LEVEL: u64 = 0xFFFD_FFFF_FFFF_FFFF;
+pub(crate) const MAX_VA_4_LEVEL: u64 = 0xFFFF_FEFF_FFFF_FFFF;
 
 // The following definitions are the zero VA for each level of the page table hierarchy. These are used to create a
 // VA range that is used to zero pages before putting them in the page table. These addresses are calculated as the
 // first VA in the penultimate index in the top level page table.
-pub(crate) const ZERO_VA_4_LEVEL: u64 = 0xFFFF_FF00_0000_0000;
 pub(crate) const ZERO_VA_5_LEVEL: u64 = 0xFFFE_0000_0000_0000;
+pub(crate) const ZERO_VA_4_LEVEL: u64 = 0xFFFF_FF00_0000_0000;
 
 // The self map index is used to map the page table itself. For simplicity, we choose the final index of the top
 // level page table. This does not conflict with any identity mapping, as the final index of the top level page table
@@ -54,11 +54,11 @@ const PDP_START_BIT: u64 = 30;
 const PD_START_BIT: u64 = 21;
 const PT_START_BIT: u64 = 12;
 
-pub(crate) const CR3_PAGE_BASE_ADDRESS_MASK: u64 = 0x000f_ffff_ffff_f000; // 40 bit - lower 12 bits for alignment
+pub(crate) const CR3_PAGE_BASE_ADDRESS_MASK: u64 = 0x000F_FFFF_FFFF_F000; // 40 bit - lower 12 bits for alignment
 
 pub(crate) const FRAME_SIZE_4KB: u64 = 0x1000; // 4KB
 pub(crate) const PAGE_TABLE_ENTRY_4KB_PAGE_TABLE_BASE_ADDRESS_SHIFT: u64 = 12u64; // lower 12 bits for alignment
-pub(crate) const PAGE_TABLE_ENTRY_4KB_PAGE_TABLE_BASE_ADDRESS_MASK: u64 = 0x000f_ffff_ffff_f000; // 40 bit - lower 12 bits for alignment
+pub(crate) const PAGE_TABLE_ENTRY_4KB_PAGE_TABLE_BASE_ADDRESS_MASK: u64 = 0x000F_FFFF_FFFF_F000; // 40 bit - lower 12 bits for alignment
 
 #[rustfmt::skip]
 #[bitfield(u64)]

--- a/src/x64/tests/x64_paging_tests.rs
+++ b/src/x64/tests/x64_paging_tests.rs
@@ -1,6 +1,6 @@
 use log::{Level, LevelFilter, Metadata, Record};
 
-use crate::PageTable;
+use crate::x64::structs::{PageLevel, VirtualAddress, MAX_VA_4_LEVEL, MAX_VA_5_LEVEL};
 use crate::{
     x64::{
         structs::{PageTableEntry, CR3_PAGE_BASE_ADDRESS_MASK, FRAME_SIZE_4KB, SELF_MAP_INDEX, ZERO_VA_INDEX},
@@ -9,6 +9,7 @@ use crate::{
     },
     MemoryAttributes, PagingType, PtError,
 };
+use crate::{PageTable, PtResult};
 
 // Sample logger for log crate to dump stuff in tests
 struct SimpleLogger;
@@ -470,8 +471,8 @@ fn test_map_memory_address_range_overflow() {
 
     let test_configs = [
         // VA range overflows
-        TestConfig { paging_type: PagingType::Paging4Level, address: 0xffff_ffff_ffff_f000, size: 0x2000 },
-        TestConfig { paging_type: PagingType::Paging5Level, address: 0xffff_ffff_ffff_f000, size: 0x2000 },
+        TestConfig { paging_type: PagingType::Paging4Level, address: MAX_VA_4_LEVEL, size: 0x2000 },
+        TestConfig { paging_type: PagingType::Paging5Level, address: MAX_VA_5_LEVEL, size: 0x2000 },
     ];
 
     for test_config in test_configs {


### PR DESCRIPTION
## Description

Reduce the usage of the `panic!` macro. Functions returning `PtResult` should not use the `panic!` macro. Minor refactoring of input address validation (`va`) checks. Other cosmetic changes.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated in QEMU

## Integration Instructions

NA