### PR TITLE
Fix shifting bug in TLBI for aarch64

### DIFF
--- a/src/aarch64/reg.rs
+++ b/src/aarch64/reg.rs
@@ -260,14 +260,14 @@ pub(crate) fn update_translation_table_entry(_translation_table_entry: u64, _mva
     #[cfg(not(test))]
     unsafe {
         let current_el = get_current_el();
-        let ls_mva = _mva << 12;
+        let pfn = _mva >> 12;
         let mut sctlr: u64;
         asm!("dsb     nshst", options(nostack));
         if current_el == 2 {
             asm!(
                 "tlbi vae2, {}",
                 "mrs {}, sctlr_el2",
-                in(reg) ls_mva,
+                in(reg) pfn,
                 out(reg) sctlr,
                 options(nostack)
             );
@@ -275,7 +275,7 @@ pub(crate) fn update_translation_table_entry(_translation_table_entry: u64, _mva
             asm!(
                 "tlbi vaae1, {}",
                 "mrs {}, sctlr_el1",
-                in(reg) ls_mva,
+                in(reg) pfn,
                 out(reg) sctlr,
                 options(nostack)
             );


### PR DESCRIPTION
## Description

This code in `update_translation_table_entry` left shifts the VA for use in `TLBI VAE2`. This should be a right shift as the specification states that the address [55:12] starts at offset 0 of the operand. 

![image](https://github.com/user-attachments/assets/63b06afe-43f8-4ac5-97d8-2832919997fc)

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
