### PR TITLE
Switch to patina-fw registry

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,8 @@
 [registries]
-UefiRust = { index = "sparse+https://pkgs.dev.azure.com/microsoft/MsUEFI/_packaging/UefiRust/Cargo/index/" }
+patina-fw = { index = "sparse+https://pkgs.dev.azure.com/patina-fw/_packaging/patina-fw/Cargo/index/" }
 
 [source.crates-io]
-replace-with = "UefiRust"
+replace-with = "patina-fw"
 
 # This tells cargo to consider the MSV of rust for our crate vs our depencencies
 [resolver]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "paging"
 version = "4.0.2"
-publish = ["UefiRust"]
+publish = ["patina-fw"]
 edition = "2021"
 license = "BSD-2-Clause-Patent"
 description = "Paging library for AArch64 & X64 architectures"

--- a/deny.toml
+++ b/deny.toml
@@ -95,7 +95,7 @@ ignore = false
 # is only published to private registries, and ignore is true, the crate will
 # not have its license(s) checked
 registries = [
-    "sparse+https://pkgs.dev.azure.com/microsoft/MsUEFI/_packaging/UefiRust/Cargo/index/",
+    "sparse+https://pkgs.dev.azure.com/patina-fw/_packaging/patina-fw/Cargo/index/",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
## Description

Moves to a public ADO feed called the `patina-fw` registry.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo update` and `cargo publish`

## Integration Instructions

- The crate will now be published to a public ADO registry. Connect to it as follows:

```
[registries]
temporary = { index = "sparse+https://pkgs.dev.azure.com/patina-fw/crates/_packaging/temporary/Cargo/index/" }
```