### PR TITLE
Rename patina-paging crate to patina_paging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "patina-paging"
-version = "5.0.0"
+name = "patina_paging"
+version = "6.0.0"
 edition = "2021"
 license = "BSD-2-Clause-Patent"
 description = "Paging library for AArch64 & X64 architectures"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -4,8 +4,8 @@ default_to_workspace = false
 [env]
 RUSTC_BOOTSTRAP = 1
 BUILD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
-UEFI_CRATES = "-p patina-paging"
-BUILD_CRATES = "-p patina-paging"
+UEFI_CRATES = "-p patina_paging"
+BUILD_CRATES = "-p patina_paging"
 COV_FLAGS = { value = "--out html --exclude-files **/tests/*", condition = { env_not_set = ["COV_FLAGS"] } }
 
 [env.development]
@@ -17,7 +17,7 @@ RUSTC_PROFILE = "release"
 RUSTC_TARGET = "release"
 
 [tasks.build-x64]
-description = """Builds patina-paging crate as UEFI target.
+description = """Builds patina_paging crate as UEFI target.
 
 Example:
     `cargo make build-x64`
@@ -28,7 +28,7 @@ command = "cargo"
 args = ["build", "--target", "x86_64-unknown-uefi", "@@split(BUILD_FLAGS, )", "@@split(UEFI_CRATES, )"]
 
 [tasks.build-aarch64]
-description = """Builds patina-paging crate as UEFI target.
+description = """Builds patina_paging crate as UEFI target.
 
 Example:
     `cargo make build-aarch64`


### PR DESCRIPTION
## Description

Rename patina-paging crate to patina_paging to stay consistent with the [RFC](https://github.com/OpenDevicePartnership/patina/pull/408) and rest of the patina crates. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`cargo make all`

## Integration Instructions

Need to update in patina repo to refer to patina_paging instead of patina-paging in Cargo.toml files. Code remains the same.