### PR TITLE
Revert Change To validate_address_range

### DIFF
--- a/src/aarch64/tests.rs
+++ b/src/aarch64/tests.rs
@@ -60,10 +60,9 @@ fn test_self_map() {
         assert!(pt.is_ok());
         let pt = pt.unwrap();
 
-        // we can't query PML4 self map base address(with FOUR_LEVEL_PML4_SELF_MAP_BASE VA), as that
-        // va is exclusively reserved for use by the self-map system.
+        // ensure the self map is present
         let res = pt.query_memory_region(FOUR_LEVEL_4_SELF_MAP_BASE, PAGE_SIZE);
-        assert!(res.is_err());
+        assert!(res.is_ok());
 
         // we can't query the zero VA because in new() it is not mapped on purpose, so we just check we mapped
         // down to the PTE level

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -618,14 +618,6 @@ impl<P: PageAllocator, Arch: PageTableHal> PageTableInternal<P, Arch> {
             return Err(PtError::UnalignedMemoryRange);
         }
 
-        let max_va = Arch::get_max_va(self.paging_type)?;
-
-        // Overflow check, size is 0-based
-        let top_va = address.try_add(size - 1)?;
-        if top_va > max_va {
-            return Err(PtError::InvalidMemoryRange);
-        }
-
         Ok(())
     }
 
@@ -661,6 +653,14 @@ impl<P: PageAllocator, Arch: PageTableHal> PageTableInternal<P, Arch> {
 
         self.validate_address_range(address, size)?;
 
+        let max_va = Arch::get_max_va(self.paging_type)?;
+
+        // Overflow check, size is 0-based
+        let top_va = address.try_add(size - 1)?;
+        if top_va > max_va {
+            return Err(PtError::InvalidMemoryRange);
+        }
+
         // We map until next alignment
         let start_va = address;
         let end_va = address + size - 1;
@@ -680,6 +680,14 @@ impl<P: PageAllocator, Arch: PageTableHal> PageTableInternal<P, Arch> {
 
         self.validate_address_range(address, size)?;
 
+        let max_va = Arch::get_max_va(self.paging_type)?;
+
+        // Overflow check, size is 0-based
+        let top_va = address.try_add(size - 1)?;
+        if top_va > max_va {
+            return Err(PtError::InvalidMemoryRange);
+        }
+
         let start_va = address;
         let end_va = address + size - 1;
 
@@ -696,6 +704,14 @@ impl<P: PageAllocator, Arch: PageTableHal> PageTableInternal<P, Arch> {
         let address = VirtualAddress::new(address);
 
         self.validate_address_range(address, size)?;
+
+        let max_va = Arch::get_max_va(self.paging_type)?;
+
+        // Overflow check, size is 0-based
+        let top_va = address.try_add(size - 1)?;
+        if top_va > max_va {
+            return Err(PtError::InvalidMemoryRange);
+        }
 
         let start_va = address;
         let end_va = address + size - 1;


### PR DESCRIPTION
## Description

During a cleanup PR, logic was moved from map/remap/unmap to validate_address_range to ensure that the address passed in was not greater than the max VA. However, it was not valid to do this because query also shares that function and it is valid to query beyond the max VA: the debugger must do this when trying to read page tables in the self map. This moves this back to the original locations and unblocks the debugger.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested running !pt in the debugger.

## Integration Instructions

N/A.
