### PR TITLE
Remove use of explicit registers and reduce asm usage

### DIFF
--- a/src/aarch64/reg.rs
+++ b/src/aarch64/reg.rs
@@ -363,12 +363,14 @@ pub(crate) unsafe fn zero_page(page: u64) {
     {
         let mut addr = page;
         for _ in 0..256 {
-            asm!(
-                "stp {zero}, {zero}, [{addr}], #16",    // Store 0 to the next 16 bytes of the page
-                addr = inout(reg) addr,
-                zero = in(reg) 0_u64,
-                options(nostack, preserves_flags)
-            );
+            unsafe {
+                asm!(
+                    "stp {zero}, {zero}, [{addr}], #16",    // Store 0 to the next 16 bytes of the page
+                    addr = inout(reg) addr,
+                    zero = in(reg) 0_u64,
+                    options(nostack, preserves_flags)
+                )
+            };
         }
     }
 }


### PR DESCRIPTION
## Description

Explicit use of registers in `asm!` statements can cause issues if not properly declared. This was observed when the aarch64 `zero_pages` function was inlined and caused a variable being tracked in x1 to be dropped due to that routines explicit and undeclared use of x1. This resulted in an invalid address being dereferenced inconsistently. 

Additionally, this change reduces the overall use of explicit `asm!` usage for readability and safety.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- [x] SBSA
- [x] AARCH64 Platform
- [x] Unit tests

## Integration Instructions

N/A
