### PR TITLE
x64: Prevent modified `rdi` in PageTableArchX64.zero_page()

### DIFF
--- a/src/aarch64/reg.rs
+++ b/src/aarch64/reg.rs
@@ -360,13 +360,10 @@ pub(crate) fn is_this_page_table_active(page_table_base: PhysicalAddress) -> boo
 /// 1. Ensure that the compiler does not optimize out the zeroing
 /// 2. Ensure that the zeroing is done as quickly as possible as without this, the zero takes a long time on
 ///    non-optimized builds
-/// 3. This function must not be inlined to ensure that the register reads and writes don't affect the caller's
-///    registers.
 ///
 /// # Safety
 /// This function is unsafe because it operates on raw pointers. It requires the caller to ensure the VA passed in
 /// is mapped.
-#[inline(never)]
 pub(crate) unsafe fn zero_page(page: u64) {
     // If the MMU is diabled, invalidate the cache so that any stale data does
     // not get later evicted to memory.


### PR DESCRIPTION
## Description

Per Rust inline assembly docs (https://doc.rust-lang.org/reference/inline-assembly.html#operand-type),
`in` states:

  - The allocated register will contain the value of <expr> at the
    start of the assembly code.
  - The allocated register must contain the same value at the end of
    the assembly code (except if a lateout is allocated to the same register).

This code:

```rust
    unsafe fn zero_page(base: VirtualAddress) {
        let _page: u64 = base.into();
        #[cfg(all(not(test), target_arch = "x86_64"))]
        unsafe {
            asm!(
            "cld",              // Clear the direction flag so that we increment rdi with each store
            "rep stosq",        // Repeat the store of qword in rax to [rdi] rcx times
            in("rcx") 0x200,    // we write 512 qwords (4096 bytes)
            in("rdi") _page,    // start at the page
            in("rax") 0,        // store 0
            options(nostack, preserves_flags)
            );
        }
    }
```

Will capture the `_page` address at the start of the assembly code
into `rdi`. However, it uses `rep stosq` which is going to:

- Store the `rax` value in `[rdi]` (`0`)
- Repat the quad word copy `rcx` times (`0x200`)
- For each operation, `rdx` will be incremented by `8` (qword)
  - Going forward due to `cld`
- Decrement `rcx` until it is zero

At the end, `rdx` is now `_page` + (`rcx` * 8) = `_page` + `0x1000`

I think it then makes sense, to manually restore the `rdi` value
since the code is inlined. This uses `r8` with `out` to let the
compiler know the register value is modified in the assembly block.

> Note: The `inline(never)` attribute in the aarch64 implementation is
> removed as well as that was mentioned as being added in response to
> the x64 issue as opposed to a specific aarch64 issue.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Compilation
- Boot `release` profile image to EFI shell on QEMU Q35

## Integration Instructions

- N/A