### PR TITLE
Coverage: Generate xml file for local tooling

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -6,7 +6,7 @@ RUSTC_BOOTSTRAP = 1
 BUILD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
 UEFI_CRATES = "-p patina_paging"
 BUILD_CRATES = "-p patina_paging"
-COV_FLAGS = { value = "--out html --out lcov --exclude-files **/tests/*", condition = { env_not_set = ["COV_FLAGS"] } }
+COV_FLAGS = { value = "--out html --out xml --exclude-files **/tests/*", condition = { env_not_set = ["COV_FLAGS"] } }
 
 [env.development]
 RUSTC_PROFILE = "dev"


### PR DESCRIPTION
## Description

Local tooling such as coverage gutters can read xmlfiles and directly highlight coverage in your vscode files. Automatically generating this file helps automate using this tool with no extra bootstrapping.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI

## Integration Instructions

N/A