### PR TITLE
Enforce canonical address ranges on external APIs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,3 +238,13 @@ pub enum PagingType {
     // 4-level paging.
     Paging4Level,
 }
+
+impl PagingType {
+    /// Gets the numbers of bits used for linear address space in this paging type.
+    pub(crate) const fn linear_address_bits(self) -> u64 {
+        match self {
+            PagingType::Paging5Level => 57,
+            PagingType::Paging4Level => 48,
+        }
+    }
+}

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -35,7 +35,7 @@ impl PageTableState {
 pub struct PageTableInternal<P: PageAllocator, Arch: PageTableHal> {
     base: PhysicalAddress,
     page_allocator: P,
-    paging_type: PagingType,
+    pub(crate) paging_type: PagingType,
     zero_va_pt_pa: Option<PhysicalAddress>,
     _arch: PhantomData<Arch>,
 }


### PR DESCRIPTION
## Description

This change adds a check that all ranges exist in the lower canonical address range. This means that the API will not access high or kernel address space ranges where the top bits are 1. This is already practically enforced at the APIs only support identity mapping and so high VA addresses are not valid input anyways.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- [x] Unit tests
- [x] Q35 boot to shell
- [x] SBSA boot to shell

## Integration Instructions

N/A
