### PR TITLE
paging: Fix asm! Macro Usage

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -26,6 +26,7 @@ words:
   - civac
   - efiapi
   - mfence
+  - nshst
   - sctlr
   - sysreg
   - uncacheable

--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -1,6 +1,3 @@
-#[allow(unused_imports)]
-use core::arch::asm;
-
 use pagetablestore::AArch64PageTableEntry;
 use reg::ExceptionLevel;
 use structs::{MAX_VA_4_LEVEL, ZERO_VA_4_LEVEL};


### PR DESCRIPTION
## Description

Patina usaged of the asm! macro was assuming that the compiler would not reorder adjacent asm! blocks. However, per the r-asm rules, the compiler does not make this guarantee: https://doc.rust-lang.org/reference/inline-assembly.html#r-asm.rules.not-successive.

This also aligns usage of isb sy as the specified instruction synchronization barrier instead of just isb. It is the same instruction now, but clarifying this is helpful.

As such, all adjacent asm! blocks are merged in this commit when required.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A.

## Integration Instructions

N/A.
