### PR TITLE
Calculate Next VA in Query

### DIFF
--- a/src/paging.rs
+++ b/src/paging.rs
@@ -487,6 +487,12 @@ impl<P: PageAllocator, Arch: PageTableHal> PageTableInternal<P, Arch> {
                     RangeMappingState::Mapped(_) => return Err(PtError::InconsistentMappingAcrossRange),
                     RangeMappingState::Unmapped => {}
                 }
+
+                // only calculate the next VA if there is another entry in the table we are processing
+                // when processing the self map, always calculating the next VA can result in overflow needlessly
+                if i + 1 < len {
+                    va = va.get_next_va(level)?;
+                }
                 continue;
             }
 


### PR DESCRIPTION
## Description

The self map VA is calculated from the start_va of a range and the level it is in. However, when querying a range if an unmapped page is encountered and there are further pages to query, query can either crash or give incorrect results.

This is because query does a continue after that, moving to the next PTE, however it does not move the start_va forward, as is done if a mapped page is encountered. As such, the self map VA is calculated based on the wrong VA. This can lead to a crash if the self map VA of that range is not in use or to potentially incorrect results if it is.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Q35 where a query was causing a fault due to an unmapped self map entry that was incorrectly calculated. This resolved the issue.

## Integration Instructions

N/A.
