### PR TITLE
CIWorkflow.yml: multiple bugfixes / cleanup

### DIFF
--- a/.github/workflows/CiWorkflow.yml
+++ b/.github/workflows/CiWorkflow.yml
@@ -16,10 +16,6 @@ on:
         required: false
         default: ""
         type: string
-    secrets:
-      PATINA_CRATES_IO_TOKEN:
-        description: "Token to access the crates.io registry"
-        required: true
 
 jobs:
   basic_ci:
@@ -70,27 +66,6 @@ jobs:
       - name: 🛠️ Download Rust Tools 🛠️
         uses: ./.github/actions/rust-tool-cache
 
-      - name: Setup Cred Provider
-        if: runner.os == 'Linux'
-        run: |
-          mkdir -p ~/.cargo
-          cat <<EOF >> ~/.cargo/config.toml
-          [registry]
-          global-credential-providers = ["cargo:token"]
-          EOF
-
-      - name: Setup Cred Provider
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $path = "$HOME\.cargo\config.toml"
-          New-Item -ItemType Directory -Force -Path "$HOME\.cargo" | Out-Null
-          "[registry]" | Out-File -Append -FilePath $path
-          'global-credential-providers = ["cargo:token"]' | Out-File -Append -FilePath $path
-
-      - name: Login to Registry
-        run: cargo login "${{ secrets.PATINA_CRATES_IO_TOKEN }}"
-
       - name: Run cargo-fmt
         run: cargo fmt --all --check
         env:
@@ -105,7 +80,7 @@ jobs:
           RUSTC_BOOTSTRAP: 1
 
       - name: Crate Release Dry Run
-        run: cargo release --no-tag --workspace --no-push --allow-branch '*'
+        run: cargo release alpha --no-tag --workspace --no-push --allow-branch '*'
         env:
           RUSTC_BOOTSTRAP: 1
 


### PR DESCRIPTION
## Description

This PR does the following:

1. Adds `alpha` to the cargo release dry run step so that we always bump the version. This is necessary as `cargo release` attempts to do a dry run with the current release in the Cargo.toml, which conflicts because it already exists.

2. Removes the usage and requirements of the crates.io token. This had multiple issues: (1) Someone with a branch on this repository edit the CI workflow and use the crates.io token however they wanted. (2) It caused CI to fail on branches from forks, as we marked the secret as required and, and secrets are not shared to forks.

3. Removes the editing of some of the rust config files with the metadata we needed to be able to download crates from azure crates for running CI.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
