### PR TITLE
Implement common stub page page_allocator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,9 @@ pub enum PtError {
 
     /// An internal error occurred. This usually indicates a bug in the paging implementation.
     InternalError,
+
+    /// Page table allocation failed.
+    AllocationFailure,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/page_allocator.rs
+++ b/src/page_allocator.rs
@@ -28,3 +28,34 @@ pub trait PageAllocator {
     ///
     fn allocate_page(&mut self, align: u64, size: u64, is_root: bool) -> PtResult<u64>;
 }
+
+/// A PageAllocator implementation that always fails to allocate pages. This can be useful when inspecting existing page
+/// tables where no new allocations are needed.
+#[derive(Default)]
+pub struct PageAllocatorStub;
+
+impl PageAllocatorStub {
+    /// Create a new PageAllocatorStub.
+    pub const fn new() -> Self {
+        PageAllocatorStub {}
+    }
+}
+
+impl PageAllocator for PageAllocatorStub {
+    fn allocate_page(&mut self, _align: u64, _size: u64, _is_root: bool) -> PtResult<u64> {
+        Err(crate::PtError::AllocationFailure)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::structs::PAGE_SIZE;
+
+    #[test]
+    fn test_page_allocator_stub() {
+        let mut allocator = PageAllocatorStub::new();
+        let result = allocator.allocate_page(PAGE_SIZE, PAGE_SIZE, false);
+        assert!(result.is_err());
+    }
+}

--- a/src/tests/paging_tests.rs
+++ b/src/tests/paging_tests.rs
@@ -12,6 +12,7 @@ use crate::{
     MemoryAttributes, PageTable, PagingType, PtError, PtResult,
     aarch64::{AArch64PageTable, PageTableArchAArch64},
     arch::PageTableHal,
+    page_allocator::PageAllocatorStub,
     structs::{PAGE_SIZE, PageLevel, VirtualAddress},
     tests::test_page_allocator::TestPageAllocator,
     x64::{PageTableArchX64, X64PageTable},
@@ -39,6 +40,8 @@ macro_rules! all_configs {
             #[allow(unused)]
             type Arch = PageTableArchX64;
             type PageTableType = X64PageTable<TestPageAllocator>;
+            #[allow(unused)]
+            type PageTableTypeStub = X64PageTable<PageAllocatorStub>;
             let paging_type = PagingType::Paging5Level;
             $body(paging_type)
         }
@@ -47,6 +50,8 @@ macro_rules! all_configs {
             #[allow(unused)]
             type Arch = PageTableArchX64;
             type PageTableType = X64PageTable<TestPageAllocator>;
+            #[allow(unused)]
+            type PageTableTypeStub = X64PageTable<PageAllocatorStub>;
             let paging_type = PagingType::Paging4Level;
             $body(paging_type)
         }
@@ -55,6 +60,8 @@ macro_rules! all_configs {
             #[allow(unused)]
             type Arch = PageTableArchAArch64;
             type PageTableType = AArch64PageTable<TestPageAllocator>;
+            #[allow(unused)]
+            type PageTableTypeStub = AArch64PageTable<PageAllocatorStub>;
             let paging_type = PagingType::Paging4Level;
             $body(paging_type)
         }
@@ -1138,8 +1145,9 @@ fn test_from_existing_page_table() {
         assert_eq!(page_allocator.pages_allocated(), num_pages);
 
         // Create a new page table from the existing one
-        let page_allocator = TestPageAllocator::new(0, paging_type);
-        let new_pt = unsafe { PageTableType::from_existing(pt.into_page_table_root(), page_allocator, paging_type) };
+        let page_allocator = PageAllocatorStub::new();
+        let new_pt =
+            unsafe { PageTableTypeStub::from_existing(pt.into_page_table_root(), page_allocator, paging_type) };
         assert!(new_pt.is_ok());
         let new_pt = new_pt.unwrap();
 


### PR DESCRIPTION
## Description

Many consumers have defined their own stub page allocator that always fails to allocate pages in order to inspect existing pages tables. This can cause code bloat, as the page tables use generics and duplicate code may be generated for each unique stub allocator. This commit adds a common stub page allocator to the library itself, reducing code duplication.

Closes #131

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Unit Tests

## Integration Instructions

N/A
