### PR TITLE
Add codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,24 @@
+# @file codecov.yml
+#
+# Codecov configuration file
+#
+##
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: Apache-2.0
+##
+codecov:
+  require_ci_to_pass: true
+coverage:
+  precision: 2
+  round: nearest
+  range: 80..90 # 0-79% red, 80-89% yellow, 90-100% green
+  status:
+    project:
+      default:
+        target: 80% # Target 80% coverage for the project
+    patch:
+      default:
+        target: 80% # Target 80% coverage for the patch
+comment:
+  layout: "condensed_header, condensed_files, condensed_footer"
+  hide_project_coverage: true # Only show patch coverage in a PR comment


### PR DESCRIPTION
## Description

This commit configures codecov with the following:
- Delay codecov from sending status until all checks are finished
- Rounds coverage percentage up or down to the nearest 2 decimal palces.
- Updates the range so that less than 80% is red, 80-89% is yellow, and 90%+ is green
- Sets the target coverage for the project and PR patch to 80% rather than keeping it approximitely what was before the commit.
- Hardcodes the comment layout, though these are the default settings.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Ran the settings through the codecov validator.

## Integration Instructions

N/A