### PR TITLE
switch to nightly toolchain

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,11 +5,5 @@
     "check",
     "--message-format=json"
   ],
-  "vscode-nmake-tools.workspaceBuildDirectories": [
-    "."
-  ],
   "rust-analyzer.cargo.targetDir": true,
-  "rust-analyzer.runnables.extraEnv": {
-    "RUSTC_BOOTSTRAP": "1"
-  },
 }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -2,7 +2,6 @@
 default_to_workspace = false
 
 [env]
-RUSTC_BOOTSTRAP = 1
 BUILD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
 UEFI_CRATES = "-p patina_paging"
 BUILD_CRATES = "-p patina_paging"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.89.0"
+channel = "nightly-2025-09-19" # One day post 1.90.0
 components = ["rust-src", "clippy", "rustfmt", "rust-docs"]
 
 [tools]

--- a/src/aarch64/reg.rs
+++ b/src/aarch64/reg.rs
@@ -6,8 +6,10 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-use core::ptr;
-use core::sync::atomic::{Ordering, compiler_fence};
+use core::{
+    ptr,
+    sync::atomic::{Ordering, compiler_fence},
+};
 
 use crate::structs::{PAGE_SIZE, PhysicalAddress};
 

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -7,13 +7,11 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-use core::marker::PhantomData;
-use core::slice;
+use core::{marker::PhantomData, slice};
 
 use crate::{
     MemoryAttributes, PagingType, PtError, PtResult, RangeMappingState,
-    arch::PageTableEntry,
-    arch::PageTableHal,
+    arch::{PageTableEntry, PageTableHal},
     page_allocator::PageAllocator,
     structs::{PAGE_SIZE, PageLevel, PhysicalAddress, SELF_MAP_INDEX, VirtualAddress, ZERO_VA_INDEX},
 };
@@ -880,8 +878,10 @@ impl<'a, Arch: PageTableHal> PageTableRange<'a, Arch> {
 #[coverage(off)]
 mod tests {
     use super::*;
-    use std::alloc::{Layout, alloc_zeroed};
-    use std::sync::atomic::{AtomicBool, AtomicU64};
+    use std::{
+        alloc::{Layout, alloc_zeroed},
+        sync::atomic::{AtomicBool, AtomicU64},
+    };
 
     static ACTIVE: AtomicBool = AtomicBool::new(false);
     static BASE: AtomicU64 = AtomicU64::new(0);

--- a/src/tests/test_page_allocator.rs
+++ b/src/tests/test_page_allocator.rs
@@ -6,18 +6,20 @@
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!
-use crate::arch::{PageTableEntry, PageTableHal};
-use crate::page_allocator::PageAllocator;
-use crate::structs::{PAGE_SIZE, PageLevel, PhysicalAddress, VirtualAddress};
-use crate::{MemoryAttributes, PagingType};
-use crate::{PtError, PtResult};
+use crate::{
+    MemoryAttributes, PagingType, PtError, PtResult,
+    arch::{PageTableEntry, PageTableHal},
+    page_allocator::PageAllocator,
+    structs::{PAGE_SIZE, PageLevel, PhysicalAddress, VirtualAddress},
+};
 
 // Add this import if get_entry is defined in crate::paging or another module
-use crate::paging::PageTableStateWithAddress;
-use crate::paging::get_entry;
-use std::alloc::{GlobalAlloc, Layout, System};
-use std::cell::RefCell;
-use std::rc::Rc;
+use crate::paging::{PageTableStateWithAddress, get_entry};
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    cell::RefCell,
+    rc::Rc,
+};
 
 // This struct will create a the buffer/memory needed for building the page
 // tables

--- a/src/x64/structs.rs
+++ b/src/x64/structs.rs
@@ -293,9 +293,11 @@ impl crate::arch::PageTableEntry for PageTableEntryX64 {
 #[coverage(off)]
 mod tests {
     use super::*;
-    use crate::MemoryAttributes;
-    use crate::arch::PageTableEntry;
-    use crate::structs::{PageLevel, PhysicalAddress, VirtualAddress};
+    use crate::{
+        MemoryAttributes,
+        arch::PageTableEntry,
+        structs::{PageLevel, PhysicalAddress, VirtualAddress},
+    };
 
     #[test]
     fn test_update_fields_sets_present_and_base_address() {


### PR DESCRIPTION
## Description

This commit switches the compiler to a nightly version dated one day past the 1.90 release date, rather then using the 1.90 release directly with RUSTC_BOOTSTRAP=1.

This change also removes all usage / reference of RUSTC_BOOTSTRAP=1 and resolves any new clippy / fmt errors.
- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
