### PR TITLE
Remove PtResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ pub trait PageTable {
     ///
     /// ## Errors
     /// * Returns `Ok(())` if successful else `Err(PtError)` if failed
-    fn map_memory_region(&mut self, address: u64, size: u64, attributes: MemoryAttributes) -> PtResult<()>;
+    fn map_memory_region(&mut self, address: u64, size: u64, attributes: MemoryAttributes) -> Result<(), PtError>;
 
     /// Function to unmap the memory region provided by the caller. The
     /// requested memory region must be fully mapped prior to this call. The
@@ -75,13 +75,13 @@ pub trait PageTable {
     ///
     /// ## Errors
     /// * Returns `Ok(())` if successful else `Err(PtError)` if failed
-    fn unmap_memory_region(&mut self, address: u64, size: u64) -> PtResult<()>;
+    fn unmap_memory_region(&mut self, address: u64, size: u64) -> Result<(), PtError>;
 
     /// Function to install the page table from this page table instance.
     ///
     /// ## Errors
     /// * Returns `Ok(())` if successful else `Err(PtError)` if failed
-    fn install_page_table(&self) -> PtResult<()>;
+    fn install_page_table(&self) -> Result<(), PtError>;
 
     /// Function to query the mapping status and return attribute of supplied
     /// memory region if it is properly and consistently mapped.
@@ -95,7 +95,7 @@ pub trait PageTable {
     ///
     /// ## Errors
     /// * Returns `Ok(MemoryAttributes)` if successful else `Err(PtError)` if failed
-    fn query_memory_region(&self, address: u64, size: u64) -> PtResult<MemoryAttributes>;
+    fn query_memory_region(&self, address: u64, size: u64) -> Result<MemoryAttributes, PtError>;
 
     /// Function to dump memory ranges with their attributes. It uses current
     /// cr3 as the base.
@@ -137,8 +137,8 @@ pub trait PageAllocator {
     /// * `size` - on x64 this will be 4KB page size.
     ///
     /// ## Returns
-    /// * `PtResult<u64>` - Physical address of the allocated page.
-    fn allocate_page(&mut self, align: u64, size: u64) -> PtResult<u64>;
+    /// * `Result<u64, PtError>` - Physical address of the allocated page.
+    fn allocate_page(&mut self, align: u64, size: u64) -> Result<u64, PtError>;
 }
 ```
 

--- a/src/aarch64/structs.rs
+++ b/src/aarch64/structs.rs
@@ -7,7 +7,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use crate::{
-    MemoryAttributes, PtError, PtResult,
+    MemoryAttributes, PtError,
     structs::{PageLevel, PhysicalAddress, VirtualAddress},
 };
 use bitfield_struct::bitfield;
@@ -102,7 +102,7 @@ impl PageTableEntryAArch64 {
         }
     }
 
-    fn set_attributes(&mut self, attributes: MemoryAttributes) -> PtResult<()> {
+    fn set_attributes(&mut self, attributes: MemoryAttributes) -> Result<(), PtError> {
         // This change pretty much follows the GcdAttributeToPageAttribute
         match attributes & MemoryAttributes::CacheAttributesMask {
             MemoryAttributes::Uncacheable => {
@@ -161,7 +161,7 @@ impl crate::arch::PageTableEntry for PageTableEntryAArch64 {
         block: bool,
         level: PageLevel,
         va: VirtualAddress,
-    ) -> PtResult<()> {
+    ) -> Result<(), PtError> {
         if !pa.is_page_aligned() {
             return Err(PtError::UnalignedPageBase);
         }
@@ -248,7 +248,7 @@ impl crate::arch::PageTableEntry for PageTableEntryAArch64 {
         );
     }
 
-    fn dump_entry(&self, va: VirtualAddress, level: PageLevel) -> PtResult<()> {
+    fn dump_entry(&self, va: VirtualAddress, level: PageLevel) -> Result<(), PtError> {
         let valid = self.valid() as u64;
         let table_desc = self.table_desc() as u64;
         let attribute_index = self.attribute_index();

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -7,7 +7,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use crate::{
-    MemoryAttributes, PagingType, PtResult,
+    MemoryAttributes, PagingType, PtError,
     structs::{PageLevel, PhysicalAddress, VirtualAddress},
 };
 
@@ -20,15 +20,15 @@ pub(crate) trait PageTableHal {
     /// to zero it. The caller must ensure that the base address is valid and points to a page table that can be
     /// safely zeroed.
     unsafe fn zero_page(base: VirtualAddress);
-    fn paging_type_supported(paging_type: PagingType) -> PtResult<()>;
-    fn get_zero_va(paging_type: PagingType) -> PtResult<VirtualAddress>;
+    fn paging_type_supported(paging_type: PagingType) -> Result<(), PtError>;
+    fn get_zero_va(paging_type: PagingType) -> Result<VirtualAddress, PtError>;
     fn invalidate_tlb(va: VirtualAddress);
     fn invalidate_tlb_all();
-    fn get_max_va(page_type: PagingType) -> PtResult<VirtualAddress>;
+    fn get_max_va(page_type: PagingType) -> Result<VirtualAddress, PtError>;
     fn is_table_active(base: u64) -> bool;
     /// SAFETY: This function is unsafe because it updates the HW page table registers to install a new page table.
     /// The caller must ensure that the base address is valid and points to a properly constructed page table.
-    unsafe fn install_page_table(base: u64) -> PtResult<()>;
+    unsafe fn install_page_table(base: u64) -> Result<(), PtError>;
     fn level_supports_pa_entry(level: PageLevel) -> bool;
     fn get_self_mapped_base(level: PageLevel, va: VirtualAddress, paging_type: PagingType) -> u64;
 }
@@ -41,13 +41,13 @@ pub(crate) trait PageTableEntry {
         leaf_entry: bool,
         level: PageLevel,
         va: VirtualAddress,
-    ) -> PtResult<()>;
+    ) -> Result<(), PtError>;
     fn get_present_bit(&self) -> bool;
     fn set_present_bit(&mut self, value: bool, va: VirtualAddress);
     fn get_next_address(&self) -> PhysicalAddress;
     fn get_attributes(&self) -> MemoryAttributes;
     fn dump_entry_header();
-    fn dump_entry(&self, va: VirtualAddress, level: PageLevel) -> PtResult<()>;
+    fn dump_entry(&self, va: VirtualAddress, level: PageLevel) -> Result<(), PtError>;
     fn points_to_pa(&self, level: PageLevel) -> bool;
     fn entry_ptr_address(&self) -> u64;
     fn unmap(&mut self, va: VirtualAddress);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,18 +15,18 @@
 //! ## Examples
 //!
 //! ``` rust
-//! use patina_paging::{aarch64, x64, MemoryAttributes, PageTable, PagingType, PtResult};
+//! use patina_paging::{aarch64, x64, MemoryAttributes, PageTable, PagingType, PtError};
 //! use patina_paging::page_allocator::PageAllocator;
 //!
 //! struct MyPageAllocator;
 //! impl PageAllocator for MyPageAllocator {
-//!    fn allocate_page(&mut self, align: u64, size: u64, is_root: bool) -> PtResult<u64> {
+//!    fn allocate_page(&mut self, align: u64, size: u64, is_root: bool) -> Result<u64, PtError> {
 //!       // Return page aligned address of the allocated page, or an error.
 //!       Ok(0)
 //!    }
 //! }
 //!
-//! fn main_x64() -> PtResult<()> {
+//! fn main_x64() -> Result<(), PtError> {
 //!     // Create a X64 page table.
 //!     let mut allocator = MyPageAllocator;
 //!     let mut page_table = x64::X64PageTable::new(allocator, PagingType::Paging4Level)?;
@@ -39,7 +39,7 @@
 //!     Ok(())
 //! }
 //!
-//! fn main_aarch64() -> PtResult<()> {
+//! fn main_aarch64() -> Result<(), PtError> {
 //!     // Create a AArch64 page table.
 //!     let mut allocator = MyPageAllocator;
 //!     let mut page_table = aarch64::AArch64PageTable::new(allocator, PagingType::Paging4Level)?;
@@ -73,8 +73,6 @@ pub(crate) mod structs;
 mod tests;
 pub mod x64;
 use bitflags::bitflags;
-
-pub type PtResult<T> = Result<T, PtError>;
 
 /// Paging error codes. These are used to indicate errors that occur during
 /// paging operations. The errors are returned as a `Result` type, where
@@ -182,7 +180,7 @@ pub trait PageTable {
     ///
     /// ## Errors
     /// * Returns `Ok(())` if successful else `Err(PtError)` if failed
-    fn map_memory_region(&mut self, address: u64, size: u64, attributes: MemoryAttributes) -> PtResult<()>;
+    fn map_memory_region(&mut self, address: u64, size: u64, attributes: MemoryAttributes) -> Result<(), PtError>;
 
     /// Function to unmap the memory region provided by the caller. The
     /// requested memory region must be fully mapped prior to this call. The
@@ -195,13 +193,13 @@ pub trait PageTable {
     ///
     /// ## Errors
     /// * Returns `Ok(())` if successful else `Err(PtError)` if failed
-    fn unmap_memory_region(&mut self, address: u64, size: u64) -> PtResult<()>;
+    fn unmap_memory_region(&mut self, address: u64, size: u64) -> Result<(), PtError>;
 
     /// Function to install the page table from this page table instance.
     ///
     /// ## Errors
     /// * Returns `Ok(())` if successful else `Err(PtError)` if failed
-    fn install_page_table(&mut self) -> PtResult<()>;
+    fn install_page_table(&mut self) -> Result<(), PtError>;
 
     /// Function to query the mapping status and return attribute of supplied
     /// memory region if it is properly and consistently mapped.
@@ -215,7 +213,7 @@ pub trait PageTable {
     ///
     /// ## Errors
     /// * Returns `Ok(MemoryAttributes)` if successful else `Err(PtError)` if failed
-    fn query_memory_region(&self, address: u64, size: u64) -> PtResult<MemoryAttributes>;
+    fn query_memory_region(&self, address: u64, size: u64) -> Result<MemoryAttributes, PtError>;
 
     /// Function to dump memory ranges with their attributes. It uses current
     /// cr3 as the base. This function can be used from
@@ -224,7 +222,7 @@ pub trait PageTable {
     /// ## Arguments
     /// * `address` - The memory address to map.
     /// * `size` - The memory size to map.
-    fn dump_page_tables(&self, address: u64, size: u64) -> PtResult<()>;
+    fn dump_page_tables(&self, address: u64, size: u64) -> Result<(), PtError>;
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/page_allocator.rs
+++ b/src/page_allocator.rs
@@ -1,4 +1,4 @@
-use crate::PtResult;
+use crate::PtError;
 
 /// PageAllocator trait facilitates `allocate_page()` method for allocating new
 /// pages. This trait must be implemented by the consumer of this library.
@@ -24,9 +24,9 @@ pub trait PageAllocator {
     ///
     /// ## Returns
     ///
-    /// * `PtResult<u64>` - Physical address of the allocated page.
+    /// * `Result<u64, PtError>` - Physical address of the allocated page.
     ///
-    fn allocate_page(&mut self, align: u64, size: u64, is_root: bool) -> PtResult<u64>;
+    fn allocate_page(&mut self, align: u64, size: u64, is_root: bool) -> Result<u64, PtError>;
 }
 
 /// A PageAllocator implementation that always fails to allocate pages. This can be useful when inspecting existing page
@@ -42,7 +42,7 @@ impl PageAllocatorStub {
 }
 
 impl PageAllocator for PageAllocatorStub {
-    fn allocate_page(&mut self, _align: u64, _size: u64, _is_root: bool) -> PtResult<u64> {
+    fn allocate_page(&mut self, _align: u64, _size: u64, _is_root: bool) -> Result<u64, PtError> {
         Err(crate::PtError::AllocationFailure)
     }
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -11,7 +11,7 @@ use core::{
     ops::{Add, Sub},
 };
 
-use crate::{PagingType, PtError, PtResult};
+use crate::{PagingType, PtError};
 
 // Constants for common sizes.
 pub const SIZE_4KB: u64 = 0x1000;
@@ -129,7 +129,7 @@ impl VirtualAddress {
     /// This will return the next virtual address that is aligned to the current entry.
     /// If the next address overflows, it will return the maximum virtual address, which occurs when querying the
     /// self map.
-    pub fn get_next_va(&self, level: PageLevel) -> PtResult<VirtualAddress> {
+    pub fn get_next_va(&self, level: PageLevel) -> Result<VirtualAddress, PtError> {
         self.round_up(level).add(1)
     }
 
@@ -155,7 +155,7 @@ impl VirtualAddress {
 
     /// This will return the range length between self and end (inclusive)
     /// In the case of underflow, it will return 0
-    pub fn length_through(&self, end: VirtualAddress) -> PtResult<u64> {
+    pub fn length_through(&self, end: VirtualAddress) -> Result<u64, PtError> {
         match end.0.checked_sub(self.0) {
             Some(0) => Ok(0),
             Some(result) => Ok(result + 1),
@@ -183,7 +183,7 @@ impl Display for VirtualAddress {
 }
 
 impl Add<u64> for VirtualAddress {
-    type Output = PtResult<Self>;
+    type Output = Result<Self, PtError>;
 
     fn add(self, rhs: u64) -> Self::Output {
         match self.0.checked_add(rhs) {
@@ -194,7 +194,7 @@ impl Add<u64> for VirtualAddress {
 }
 
 impl Sub<u64> for VirtualAddress {
-    type Output = PtResult<Self>;
+    type Output = Result<Self, PtError>;
 
     fn sub(self, rhs: u64) -> Self::Output {
         match self.0.checked_sub(rhs) {

--- a/src/tests/paging_tests.rs
+++ b/src/tests/paging_tests.rs
@@ -9,7 +9,7 @@
 use log::{Level, LevelFilter, Metadata, Record};
 
 use crate::{
-    MemoryAttributes, PageTable, PagingType, PtError, PtResult,
+    MemoryAttributes, PageTable, PagingType, PtError,
     aarch64::{AArch64PageTable, PageTableArchAArch64},
     arch::PageTableHal,
     page_allocator::PageAllocatorStub,
@@ -94,7 +94,7 @@ fn subtree_num_pages<Arch: PageTableHal>(
     mut address: VirtualAddress,
     mut size: u64,
     level: PageLevel,
-) -> PtResult<u64> {
+) -> Result<u64, PtError> {
     assert!(address.is_page_aligned());
     assert!(size > 0);
     assert!(VirtualAddress::new(size).is_page_aligned());
@@ -141,7 +141,11 @@ fn subtree_num_pages<Arch: PageTableHal>(
     Ok(pages)
 }
 
-fn num_page_tables_required<Arch: PageTableHal>(address: u64, size: u64, paging_type: PagingType) -> PtResult<u64> {
+fn num_page_tables_required<Arch: PageTableHal>(
+    address: u64,
+    size: u64,
+    paging_type: PagingType,
+) -> Result<u64, PtError> {
     let address = VirtualAddress::new(address);
     if size == 0 || !address.is_page_aligned() {
         return Err(PtError::UnalignedAddress);

--- a/src/tests/test_page_allocator.rs
+++ b/src/tests/test_page_allocator.rs
@@ -7,7 +7,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use crate::{
-    MemoryAttributes, PagingType, PtError, PtResult,
+    MemoryAttributes, PagingType, PtError,
     arch::{PageTableEntry, PageTableHal},
     page_allocator::PageAllocator,
     structs::{PAGE_SIZE, PageLevel, PhysicalAddress, VirtualAddress},
@@ -201,13 +201,13 @@ impl TestPageAllocator {
         self.ref_impl.borrow().get_memory_base()
     }
 
-    fn get_page(&self, index: u64) -> PtResult<*const u64> {
+    fn get_page(&self, index: u64) -> Result<*const u64, PtError> {
         self.ref_impl.borrow().get_page(index)
     }
 }
 
 impl PageAllocator for TestPageAllocator {
-    fn allocate_page(&mut self, align: u64, size: u64, _is_root: bool) -> PtResult<u64> {
+    fn allocate_page(&mut self, align: u64, size: u64, _is_root: bool) -> Result<u64, PtError> {
         assert!(size == PAGE_SIZE);
         self.ref_impl.borrow_mut().allocate_page(align, size)
     }
@@ -235,7 +235,7 @@ impl TestPageAllocatorImpl {
         Self { memory: (ptr, layout), page_index: 0, max_pages: num_pages }
     }
 
-    fn allocate_page(&mut self, _align: u64, _size: u64) -> PtResult<u64> {
+    fn allocate_page(&mut self, _align: u64, _size: u64) -> Result<u64, PtError> {
         if self.page_index >= self.max_pages {
             return Err(PtError::OutOfResources);
         }
@@ -245,7 +245,7 @@ impl TestPageAllocatorImpl {
         Ok(ptr)
     }
 
-    fn get_page(&self, index: u64) -> PtResult<*const u64> {
+    fn get_page(&self, index: u64) -> Result<*const u64, PtError> {
         if index >= self.page_index {
             return Err(PtError::OutOfResources);
         }

--- a/src/x64/structs.rs
+++ b/src/x64/structs.rs
@@ -7,7 +7,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use crate::{
-    MemoryAttributes, PtResult,
+    MemoryAttributes, PtError,
     structs::{PageLevel, PhysicalAddress, VirtualAddress},
     x64::{PD, PDP, PML4, PML5, PT, invalidate_tlb},
 };
@@ -125,7 +125,7 @@ impl crate::arch::PageTableEntry for PageTableEntryX64 {
         leaf_entry: bool,
         level: PageLevel,
         va: VirtualAddress,
-    ) -> PtResult<()> {
+    ) -> Result<(), PtError> {
         // ensure break-before-make by working on a copy and then swapping. PageTableEntryX64 derives Copy, so this
         // will create a copy of the entry to modify
         let mut copy = *self;
@@ -193,7 +193,7 @@ impl crate::arch::PageTableEntry for PageTableEntryX64 {
         attributes
     }
 
-    fn dump_entry(&self, va: VirtualAddress, level: PageLevel) -> PtResult<()> {
+    fn dump_entry(&self, va: VirtualAddress, level: PageLevel) -> Result<(), PtError> {
         let nx = self.nx() as u64;
         let available_high = self.available_high() as u64;
         let page_table_base_address = self.page_table_base_address();


### PR DESCRIPTION
## Description

This commit removes the PtResult type that was a wrapper over Result<T, PtError>. This does not provide added value, instead of using the standard Result type, consumers must use this new type.

Custom errors provide a lot of value, so PtError is left.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested with accompanying patina change booting Q35 and SBSA to Windows.

## Integration Instructions

This is a breaking change because the external API has changed to `Result` instead of `PtResult`. Consumers should change to accept `Result` instead of `PtResult`.
