### PR TITLE
Code Coverage: Only post status to pull requests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -16,9 +16,11 @@ coverage:
     project:
       default:
         target: 80% # Target 80% coverage for the project
+        only_pulls: true
     patch:
       default:
         target: 80% # Target 80% coverage for the patch
+        only_pulls: true
 comment:
   layout: "condensed_header, condensed_files, condensed_footer"
   hide_project_coverage: true # Only show patch coverage in a PR comment


### PR DESCRIPTION
## Description

This uses only_pulls which "Only post a status to pull requests, defaults to false. If true no status will be posted for commits not on a pull request."

see: https://docs.codecov.com/docs/commit-status#only_pulls

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
