### PR TITLE
Update to patina-devops 0.1.1

### DIFF
--- a/.github/workflows/MiriWorkflow.yml
+++ b/.github/workflows/MiriWorkflow.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🛠️ Download Rust Tools 🛠️
-        uses: OpenDevicePartnership/patina-devops/.github/actions/rust-tool-cache@v0.0.4
+        uses: OpenDevicePartnership/patina-devops/.github/actions/rust-tool-cache@v0.1.1
 
       - name: Install miri
         run: rustup +nightly component add miri

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   ci_workflow:
     name: Run
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/CiWorkflow.yml@v0.0.4
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/CiWorkflow.yml@v0.1.1
     secrets: inherit
     with:
       build-tasks: "build,build-x64,build-aarch64"

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -29,5 +29,5 @@ jobs:
       contents: read
       pull-requests: write
 
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/Labeler.yml@v0.0.4
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/Labeler.yml@v0.1.1
     secrets: inherit

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -22,5 +22,5 @@ jobs:
     permissions:
       issues: write
 
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/LabelSyncer.yml@v0.0.4
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/LabelSyncer.yml@v0.1.1
     secrets: inherit

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   release:
     name: Release
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/ReleaseWorkflow.yml@v0.0.4
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/ReleaseWorkflow.yml@v0.1.1
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/update-release-draft.yml
+++ b/.github/workflows/update-release-draft.yml
@@ -25,5 +25,5 @@ jobs:
       contents: write
       pull-requests: write
 
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/UpdateReleaseDraft.yml@v0.0.4
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/UpdateReleaseDraft.yml@v0.1.1
     secrets: inherit


### PR DESCRIPTION
## Description

Updates patina-devops to v0.1.1 which should result in a shorter PR Gate runtime.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
