### PR TITLE
Update to patina-devops v0.2.2

### DIFF
--- a/.github/workflows/MiriWorkflow.yml
+++ b/.github/workflows/MiriWorkflow.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🛠️ Download Rust Tools 🛠️
-        uses: OpenDevicePartnership/patina-devops/.github/actions/rust-tool-cache@v0.1.1
+        uses: OpenDevicePartnership/patina-devops/.github/actions/rust-tool-cache@v0.2.2
 
       - name: Install miri
         run: rustup +nightly component add miri

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   ci_workflow:
     name: Run
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/CiWorkflow.yml@v0.1.1
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/CiWorkflow.yml@v0.2.2
     secrets: inherit
     with:
       build-tasks: "build,build-x64,build-aarch64"

--- a/.github/workflows/crate-version-update.yml
+++ b/.github/workflows/crate-version-update.yml
@@ -1,0 +1,31 @@
+# @file crate-version-updater
+#
+# A Github workflow that creates or updates a pull request to update the crate version numbers of local crates to match
+# the version specified in the current draft release tag.
+#
+# This workflow will only create a PR when triggered manually. However, it will run automatically after the "Update
+# Release Draft" workflow completes, to update the PR if it already exists.
+#
+##
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+##
+name: Create Crate Version Update PR
+
+on:
+  workflow_run:
+    workflows: ["Update Release Draft"]
+    types: ["completed"]
+
+  workflow_dispatch:
+
+jobs:
+  crate-version-update-pr:
+    name: Run
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/CrateVersionUpdater.yml@v0.2.2
+    with:
+      ignore-prefix: 'v'
+      create-pr: ${{ github.event_name == 'workflow_dispatch' }}
+    secrets: inherit
+    permissions:
+      contents: write

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -29,5 +29,5 @@ jobs:
       contents: read
       pull-requests: write
 
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/Labeler.yml@v0.1.1
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/Labeler.yml@v0.2.2
     secrets: inherit

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -22,5 +22,5 @@ jobs:
     permissions:
       issues: write
 
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/LabelSyncer.yml@v0.1.1
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/LabelSyncer.yml@v0.2.2
     secrets: inherit

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,14 +10,14 @@
 name: Publish Release
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [ main ]
+    paths: [ Cargo.toml ]
 
 jobs:
   release:
     name: Release
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/ReleaseWorkflow.yml@v0.1.1
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/ReleaseWorkflow.yml@v0.2.2
+    with:
+      ignore-prefix: 'v'
     secrets: inherit
-    permissions:
-      contents: write
-      actions: read

--- a/.github/workflows/update-release-draft.yml
+++ b/.github/workflows/update-release-draft.yml
@@ -25,5 +25,5 @@ jobs:
       contents: write
       pull-requests: write
 
-    uses: OpenDevicePartnership/patina-devops/.github/workflows/UpdateReleaseDraft.yml@v0.1.1
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/UpdateReleaseDraft.yml@v0.2.2
     secrets: inherit


### PR DESCRIPTION
## Description

Updates the repository to patina-devops v0.2.2 which changes the release process as described in the release notes of patina-devops:

ref:
https://github.com/OpenDevicePartnership/patina-devops/releases/tag/v0.2.0

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
