### PR TITLE
AArch64: Enforce Device Memory Must be Non-Executable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub enum PtError {
     /// No mapping exists for the entire range.
     NoMapping,
 
-    /// The memory range is mapped with different attributes.
+    /// The attributes attempting to be set are incompatible
     IncompatibleMemoryAttributes,
 
     /// Provided base address is not aligned to the page size.
@@ -121,6 +121,9 @@ pub enum PtError {
 
     /// Page table allocation failed.
     AllocationFailure,
+
+    /// The attributes across the range are not the same
+    NonUniformMemoryAttributes,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -438,7 +438,7 @@ impl<P: PageAllocator, Arch: PageTableHal> PageTableInternal<P, Arch> {
                     RangeMappingState::Unmapped => return Err(PtError::InconsistentMappingAcrossRange),
                     RangeMappingState::Mapped(attrs) => {
                         if *attrs != current_attributes {
-                            return Err(PtError::IncompatibleMemoryAttributes);
+                            return Err(PtError::NonUniformMemoryAttributes);
                         }
                     }
                 }


### PR DESCRIPTION
## Description

The ARM ARM v8 section B2.7.2 states that setting any device memory as executable is a programming error. This has been confirmed by seeing crashes on physical platforms from seeing speculative execution attempt instruction fetches from device memory that was not ready to be read.

This enforces that device memory be marked NX.

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on physical ARM64 platform.

## Integration Instructions

This is a breaking change because a previously accepted attribute combination no longer is. Patina prior to https://github.com/OpenDevicePartnership/patina/pull/1032 being merged will fault on this patina-paging version for AArch64 platforms if callers were not setting NX themselves.

Because this was a breaking change in and of itself, another was embedded in this to add a new error type and repurpose an existing one. This requires no change in Patina.

Note: This is a breaking change, but is not required to be released immediately as Patina is working around this itself. A new patina-paging release will be deferred until something else requires it.
