### PR TITLE
Makefile.toml: Clean Coverage Artifacts Before Running Coverage

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -66,12 +66,20 @@ description = "Checks rust code for errors. Example `cargo make check`"
 clear = true
 run_task = [{ name = ["check_no_std", "check_std", "check_tests"], parallel = true }]
 
+[tasks.llvm-cov-clean]
+description = "Clean coverage data"
+private = true
+install_crate = false
+command = "cargo"
+args = ["llvm-cov", "clean", "--workspace"]
+
 [tasks.test]
 description = "Run tests and collect coverage data without generating reports."
 install_crate = false
 clear = true
 command = "cargo"
 args = ["llvm-cov", "@@split(COV_FLAGS, )", "--no-report"]
+dependencies = ["llvm-cov-clean"]
 
 [tasks.coverage-lcov]
 description = "Generate an LCOV coverage report from collected data."


### PR DESCRIPTION
## Description

cargo-llvm-cov automatically cleans coverage artifacts before running in order to have accurate coverage results. However, if --no-report is passed, it does not automatically clean the coverage artifacts.

--no-report was added to cargo-llvm-cov when refactoring the report output, but a call to cargo llvm-cov clean first was not done. This is fine for CI builds, but for local runs, it will produce inaccurate coverage if there are existing coverage artifacts.

This fixes that by ensuring cargo llvm-cov clean is called first.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Cherry-picked from Patina.

## Integration Instructions

N/A.
