### PR TITLE
Rename Uncacheable Attrs to Uncached

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct MemoryAttributes: u64 {
         // Memory Caching Attributes
-        const Uncacheable       = 0x00000000_00000001u64;
+        const Uncached          = 0x00000000_00000001u64;
         const WriteCombining    = 0x00000000_00000002u64;
         const WriteThrough      = 0x00000000_00000004u64;
         const Writeback         = 0x00000000_00000008u64;
-        const UncacheableExport = 0x00000000_00000010u64;
+        const UncachedExport    = 0x00000000_00000010u64;
         const WriteProtect      = 0x00000000_00001000u64;
 
         // Memory Access Attributes
@@ -34,11 +34,11 @@ bitflags! {
         const ReadOnly          = 0x00000000_00020000u64;   // Maps to Read/Write bit on X64
 
 
-        const CacheAttributesMask = Self::Uncacheable.bits() |
+        const CacheAttributesMask = Self::Uncached.bits() |
                                     Self::WriteCombining.bits() |
                                     Self::WriteThrough.bits() |
                                     Self::Writeback.bits() |
-                                    Self::UncacheableExport.bits() |
+                                    Self::UncachedExport.bits() |
                                     Self::WriteProtect.bits();
 
         const AccessAttributesMask = Self::ReadProtect.bits() |
@@ -56,8 +56,8 @@ pub trait PageTable {
     /// * `address` - The memory address to map.
     /// * `size` - The memory size to map.
     /// * `attributes` - The memory attributes to map. The acceptable
-    ///   input will be ExecuteProtect, ReadOnly, as well as Uncacheable,
-    ///   WriteCombining, WriteThrough, Writeback, UncacheableExport.
+    ///   input will be ExecuteProtect, ReadOnly, as well as Uncached,
+    ///   WriteCombining, WriteThrough, Writeback, UncachedExport.
     ///   Compatible attributes can be "Ored"
     ///
     /// ## Errors

--- a/cspell.yml
+++ b/cspell.yml
@@ -34,6 +34,5 @@ words:
   - pdbhelper
   - sctlr
   - sysreg
-  - uncacheable
   - unmapping
   - vmalle

--- a/src/aarch64/structs.rs
+++ b/src/aarch64/structs.rs
@@ -105,11 +105,11 @@ impl PageTableEntryAArch64 {
     fn set_attributes(&mut self, attributes: MemoryAttributes) -> Result<(), PtError> {
         // This change pretty much follows the GcdAttributeToPageAttribute
         match attributes & MemoryAttributes::CacheAttributesMask {
-            MemoryAttributes::Uncacheable => {
+            MemoryAttributes::Uncached => {
                 if !attributes.contains(MemoryAttributes::ExecuteProtect) {
                     // Per ARM ARM v8 section B2.7.2, it is a programming error to have
                     // any device memory that is executable.
-                    log::error!("Executable uncacheable memory is not allowed");
+                    log::error!("Executable Uncached memory is not allowed");
                     return Err(PtError::IncompatibleMemoryAttributes);
                 }
                 self.set_attribute_index(0);
@@ -213,11 +213,11 @@ impl crate::arch::PageTableEntry for PageTableEntryAArch64 {
             attributes = MemoryAttributes::ReadProtect;
         } else {
             match self.attribute_index() {
-                0 => attributes |= MemoryAttributes::Uncacheable,
+                0 => attributes |= MemoryAttributes::Uncached,
                 1 => attributes |= MemoryAttributes::WriteCombining,
                 2 => attributes |= MemoryAttributes::WriteThrough,
                 3 => attributes |= MemoryAttributes::Writeback,
-                _ => attributes |= MemoryAttributes::Uncacheable,
+                _ => attributes |= MemoryAttributes::Uncached,
             }
 
             if self.access_permission() == 2 {
@@ -405,12 +405,12 @@ mod tests {
     }
 
     #[test]
-    fn test_get_attributes_uncacheable() {
+    fn test_get_attributes_uncached() {
         let mut desc = PageTableEntryAArch64::new();
         desc.set_valid(true);
         desc.set_attribute_index(0);
         let attrs = desc.get_attributes();
-        assert!(attrs.contains(MemoryAttributes::Uncacheable));
+        assert!(attrs.contains(MemoryAttributes::Uncached));
     }
 
     #[test]
@@ -444,9 +444,9 @@ mod tests {
     }
 
     #[test]
-    fn test_set_attributes_uncacheable_execute_protect_error() {
+    fn test_set_attributes_uncached_execute_protect_error() {
         let mut desc = PageTableEntryAArch64::new();
-        let attrs = MemoryAttributes::Uncacheable;
+        let attrs = MemoryAttributes::Uncached;
         let res = desc.set_attributes(attrs);
         assert!(matches!(res, Err(PtError::IncompatibleMemoryAttributes)));
 
@@ -457,7 +457,7 @@ mod tests {
     #[test]
     fn test_set_attributes_with_multiple_cache_attrs() {
         let mut desc = PageTableEntryAArch64::new();
-        let attrs = MemoryAttributes::Uncacheable | MemoryAttributes::WriteCombining;
+        let attrs = MemoryAttributes::Uncached | MemoryAttributes::WriteCombining;
         let res = desc.set_attributes(attrs);
         assert!(matches!(res, Err(PtError::IncompatibleMemoryAttributes)));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,11 +140,11 @@ bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct MemoryAttributes: u64 {
         // Memory Caching Attributes
-        const Uncacheable       = 0x00000000_00000001u64;
+        const Uncached       = 0x00000000_00000001u64;
         const WriteCombining    = 0x00000000_00000002u64;
         const WriteThrough      = 0x00000000_00000004u64;
         const Writeback         = 0x00000000_00000008u64;
-        const UncacheableExport = 0x00000000_00000010u64;
+        const UncachedExport = 0x00000000_00000010u64;
         const WriteProtect      = 0x00000000_00001000u64;
 
         // Memory Access Attributes
@@ -153,11 +153,11 @@ bitflags! {
         const ReadOnly          = 0x00000000_00020000u64;   // Maps to Read/Write bit on X64
 
 
-        const CacheAttributesMask = Self::Uncacheable.bits() |
+        const CacheAttributesMask = Self::Uncached.bits() |
                                    Self::WriteCombining.bits() |
                                    Self::WriteThrough.bits() |
                                    Self::Writeback.bits() |
-                                   Self::UncacheableExport.bits() |
+                                   Self::UncachedExport.bits() |
                                    Self::WriteProtect.bits();
 
         const AccessAttributesMask = Self::ReadProtect.bits() |
@@ -177,8 +177,8 @@ pub trait PageTable {
     /// * `address` - The memory address to map.
     /// * `size` - The memory size to map.
     /// * `attributes` - The memory attributes to map. The acceptable
-    ///   input will be ExecuteProtect, ReadOnly, as well as Uncacheable,
-    ///   WriteCombining, WriteThrough, Writeback, UncacheableExport
+    ///   input will be ExecuteProtect, ReadOnly, as well as Uncached,
+    ///   WriteCombining, WriteThrough, Writeback, UncachedExport
     ///   Compatible attributes can be "Ored"
     ///
     /// ## Errors


### PR DESCRIPTION
## Description

This renames the Uncacheable and UncacheableExport attributes to Uncached and UncachedExport to better reflect they are set attributes, not capabilities, e.g. if a region is set as MemoryAttributes::Uncached it is uncached, not uncacheable.

UncachedExport was considered on being removed as it was for IA64, but as it is defined in the UEFI spec, the definition is left.

Note: patina-paging v10 is pending with another breaking change, so this is planned to be added to that, but not released yet until a need occurs. This was just done opportunistically to catch another breaking change before it was released.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A.

## Integration Instructions

Update the names of the attributes.
