### PR TITLE
Fixing T0SZ allowed values

### DIFF
--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -132,7 +132,7 @@ fn detect_paging_type() -> Result<PagingType, PtError> {
     let t0sz = tcr & 0x3F; // T0SZ is bits [5:0]
     let va_bits = 64 - t0sz;
     match va_bits {
-        48 => Ok(PagingType::Paging4Level),
+        40..=48 => Ok(PagingType::Paging4Level),
         52 => Ok(PagingType::Paging5Level),
         _ => Err(PtError::UnsupportedPagingType),
     }


### PR DESCRIPTION
## Description

Enabling T0SZ values 16-24 without the need to disable MMU.
This is intended to fix:
https://github.com/OpenDevicePartnership/patina-paging/issues/189

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on a proprietary HW 

## Integration Instructions

N/A