### PR TITLE
deny.toml: Update license exceptions and duplicate skip list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -91,8 +91,6 @@ exceptions = [
     # Each entry is the crate and version constraint, and its specific allow
     # list
     #{ allow = ["Zlib"], crate = "adler32" },
-    { allow = ["0BSD"], crate = "managed" },
-    { allow = ["BSD-3-Clause"], crate = "alloc-no-stdlib" },
     { allow = ["Unicode-3.0"], crate = "unicode-ident" }
 ]
 
@@ -171,8 +169,6 @@ deny = [
 skip = [
     #"ansi_term@0.11.0",
     #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
-
-    { crate = "bitflags", reason = "Need https://github.com/gz/rust-x86/pull/150 to be merged into rust-x86." }
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive


### PR DESCRIPTION
## Description

1. The relatively small number of dependencies in this repo no longer require exceptions for the `0BSD` and `BSD-3-Clause` licenses.
2. This `bitflags` duplicate skip entry is no longer needed.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

#### Before (`cargo make deny`)

```
[cargo-make] INFO - cargo make 0.37.24
[cargo-make] INFO - 
[cargo-make] INFO - Project: patina_paging
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: deny
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Execute Command: "cargo" "deny" "check"
warning[license-exception-not-encountered]: license exception was not encountered
   ┌─ patina-paging\deny.toml:94:34
   │
94 │     { allow = ["0BSD"], crate = "managed" },
   │                                  ━━━━━━━ unmatched license exception

warning[license-exception-not-encountered]: license exception was not encountered
   ┌─ patina-paging\deny.toml:95:42
   │
95 │     { allow = ["BSD-3-Clause"], crate = "alloc-no-stdlib" },
   │                                          ━━━━━━━━━━━━━━━ unmatched license exception

warning[unnecessary-skip]: skip 'bitflags' applied to a crate with only one version
    ┌─ patina-paging\deny.toml:175:16
    │
175 │     { crate = "bitflags", reason = "Need https://github.com/gz/rust-x86/pull/150 to be merged into rust-x86." }
    │                ━━━━━━━━             ──────────────────────────────────────────────────────────────────────── reason
    │                │                     
    │                unnecessary skip configuration

advisories ok, bans ok, licenses ok, sources ok
```

#### After (`cargo make deny`)

```
[cargo-make] INFO - cargo make 0.37.24
[cargo-make] INFO - 
[cargo-make] INFO - Project: patina_mtrr
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: deny
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Execute Command: "cargo" "deny" "check"
advisories ok, bans ok, licenses ok, sources ok
[cargo-make] INFO - Build Done in 7.18 seconds.
```

## Integration Instructions

- N/A