### PR TITLE
Fixing flaky tests in paging.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ bitflags = "2.6.0"
 log = { version = "^0.4", default-features = false }
 cfg-if = "1.0.0"
 
+[dev-dependencies]
+serial_test = "3.5"
+
 [features]
 doc = []
 supervisor = []

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -1089,11 +1089,13 @@ mod tests {
     use super::*;
     use std::{
         alloc::{Layout, alloc_zeroed},
-        sync::atomic::{AtomicBool, AtomicU64},
+        cell::Cell,
     };
 
-    static ACTIVE: AtomicBool = AtomicBool::new(false);
-    static BASE: AtomicU64 = AtomicU64::new(0);
+    thread_local! {
+        static ACTIVE: Cell<bool> = const { Cell::new(false) };
+        static BASE: Cell<u64> = const { Cell::new(0) };
+    }
 
     // Dummy Arch implementation for testing
     #[derive(PartialEq, Debug)]
@@ -1108,7 +1110,7 @@ mod tests {
         }
         fn get_self_mapped_base(_level: PageLevel, _va: VirtualAddress, _paging_type: PagingType) -> u64 {
             // for the test we can't use the real self map, so just return the PT base
-            BASE.load(std::sync::atomic::Ordering::Relaxed)
+            BASE.with(|base| base.get())
         }
         fn get_zero_va(_paging_type: PagingType) -> Result<VirtualAddress, PtError> {
             Ok(VirtualAddress::new(0x1000))
@@ -1117,7 +1119,7 @@ mod tests {
             Ok(VirtualAddress::new(0xFFFF_FFFF_FFFF_0000))
         }
         fn is_table_active(_base: u64) -> bool {
-            ACTIVE.load(std::sync::atomic::Ordering::Relaxed)
+            ACTIVE.with(|active| active.get())
         }
         unsafe fn zero_page(_va: VirtualAddress) {}
         unsafe fn install_page_table(_base: u64, _paging_type: PagingType) -> Result<(), PtError> {
@@ -1219,7 +1221,7 @@ mod tests {
             self.allocated_pages.borrow_mut().push(addr);
 
             if is_root {
-                BASE.store(addr, std::sync::atomic::Ordering::Relaxed);
+                BASE.with(|base| base.set(addr));
             }
 
             Ok(addr)
@@ -1243,11 +1245,11 @@ mod tests {
         };
 
         // By default, the table is not active, so should be Inactive
-        ACTIVE.store(false, std::sync::atomic::Ordering::Relaxed);
+        ACTIVE.with(|active| active.set(false));
         assert_eq!(pt.get_state(), PageTableState::Inactive);
 
         // Set table as active, but self-map entry is not present or doesn't match base
-        ACTIVE.store(true, std::sync::atomic::Ordering::Relaxed);
+        ACTIVE.with(|active| active.set(true));
 
         // Overwrite the self-map entry to not present
         let root_level = PageLevel::root_level(pt.paging_type);

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -1087,17 +1087,18 @@ impl<'a, Arch: PageTableHal> PageTableRange<'a, Arch> {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::{
         alloc::{Layout, alloc_zeroed},
-        sync::{
-            Mutex, MutexGuard, PoisonError,
-            atomic::{AtomicBool, AtomicU64},
-        },
+        sync::atomic::{AtomicBool, AtomicU64},
     };
 
+    // `DummyArch` emulates hardware state through these process-wide statics. Tests that build a
+    // `DummyArch` page table are marked `#[serial]` so the libtest harness never runs them
+    // concurrently; otherwise one test's `make_table()` could overwrite `BASE` while another walks
+    // its own table in self-mapped mode. See issue #215.
     static ACTIVE: AtomicBool = AtomicBool::new(false);
     static BASE: AtomicU64 = AtomicU64::new(0);
-    static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     // Dummy Arch implementation for testing
     #[derive(PartialEq, Debug)]
@@ -1230,17 +1231,17 @@ mod tests {
         }
     }
 
-    fn make_table() -> (PageTableInternal<DummyAllocator, DummyArch>, DummyAllocator, MutexGuard<'static, ()>) {
-        let guard = TEST_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+    fn make_table() -> (PageTableInternal<DummyAllocator, DummyArch>, DummyAllocator) {
         let allocator = DummyAllocator::new();
         let allocator_clone = allocator.clone();
         let pt = PageTableInternal::new(allocator, PagingType::Paging4Level).unwrap();
-        (pt, allocator_clone, guard)
+        (pt, allocator_clone)
     }
 
     #[test]
+    #[serial]
     fn test_get_state_variants() {
-        let (pt, allocator, _guard) = make_table();
+        let (pt, allocator) = make_table();
 
         // Cleanup function to ensure memory is freed
         let cleanup = || {
@@ -1277,8 +1278,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_validate_address_range() {
-        let (pt, allocator, _guard) = make_table();
+        let (pt, allocator) = make_table();
 
         assert!(pt.validate_address_range(VirtualAddress::new(0x1000), 0x2000).is_ok());
         assert_eq!(pt.validate_address_range(VirtualAddress::new(0x1001), 0x2000), Err(PtError::UnalignedAddress));
@@ -1289,8 +1291,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_allocate_page_alignment() {
-        let (mut pt, allocator, _guard) = make_table();
+        let (mut pt, allocator) = make_table();
         let pa: u64 = pt.allocate_page(PageTableState::Inactive).unwrap().into();
         assert_eq!(pa % PAGE_SIZE, 0);
 
@@ -1298,8 +1301,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_split_large_page_error() {
-        let (mut pt, allocator, _guard) = make_table();
+        let (mut pt, allocator) = make_table();
         let mut entry = DummyPTE::new();
         entry.set_present_bit(false, VirtualAddress::new(0x0));
         let res =
@@ -1333,8 +1337,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_dump_page_tables_invalid_range() {
-        let (pt, allocator, _guard) = make_table();
+        let (pt, allocator) = make_table();
         let res = pt.dump_page_tables(0x1001, 0x1000);
         assert_eq!(res, Err(PtError::InvalidMemoryRange));
 
@@ -1357,8 +1362,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_map_memory_region_top_va_overflow() {
-        let (mut pt, allocator, _guard) = make_table();
+        let (mut pt, allocator) = make_table();
         // max_va is 0xFFFF_FFFF_FFFF_0000, so use an address near the top and a size that overflows
         let addr = 0xFFFF_FFFF_FFFF_0000;
         let size = 0x2000; // This will make top_va > max_va
@@ -1369,8 +1375,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_unmap_memory_region_top_va_overflow() {
-        let (mut pt, allocator, _guard) = make_table();
+        let (mut pt, allocator) = make_table();
         let addr = 0xFFFF_FFFF_FFFF_0000;
         let size = 0x2000;
         let res = pt.unmap_memory_region(addr, size);
@@ -1380,12 +1387,13 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_iter_mapped_regions_self_mapped_state() {
         // Exercise the iterator's self-mapped state handling. `DummyArch` resolves every self-mapped
         // level to the page table base, so the walk reads the root table for each level. A freshly
         // created table exposes no genuine leaf mappings, so the iterator yields nothing, but the
         // `ActiveSelfMapped` branch of the iterator's state handling is still executed.
-        let (pt, allocator, _guard) = make_table();
+        let (pt, allocator) = make_table();
 
         let count =
             PageTableIterator::<DummyArch>::new(pt.base, pt.paging_type, PageTableState::ActiveSelfMapped, None)

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -1231,8 +1231,6 @@ mod tests {
     }
 
     fn make_table() -> (PageTableInternal<DummyAllocator, DummyArch>, DummyAllocator, MutexGuard<'static, ()>) {
-        // Hold the shared-state lock for as long as the returned table is alive so concurrent tests
-        // cannot mutate the global `BASE`/`ACTIVE` out from under it.
         let guard = TEST_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
         let allocator = DummyAllocator::new();
         let allocator_clone = allocator.clone();

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -1091,7 +1091,7 @@ mod tests {
         alloc::{Layout, alloc_zeroed},
         sync::{
             Mutex, MutexGuard, PoisonError,
-            atomic::{AtomicBool, AtomicU64, Ordering},
+            atomic::{AtomicBool, AtomicU64},
         },
     };
 
@@ -1112,7 +1112,7 @@ mod tests {
         }
         fn get_self_mapped_base(_level: PageLevel, _va: VirtualAddress, _paging_type: PagingType) -> u64 {
             // for the test we can't use the real self map, so just return the PT base
-            BASE.load(Ordering::Relaxed)
+            BASE.load(std::sync::atomic::Ordering::Relaxed)
         }
         fn get_zero_va(_paging_type: PagingType) -> Result<VirtualAddress, PtError> {
             Ok(VirtualAddress::new(0x1000))
@@ -1121,7 +1121,7 @@ mod tests {
             Ok(VirtualAddress::new(0xFFFF_FFFF_FFFF_0000))
         }
         fn is_table_active(_base: u64) -> bool {
-            ACTIVE.load(Ordering::Relaxed)
+            ACTIVE.load(std::sync::atomic::Ordering::Relaxed)
         }
         unsafe fn zero_page(_va: VirtualAddress) {}
         unsafe fn install_page_table(_base: u64, _paging_type: PagingType) -> Result<(), PtError> {
@@ -1223,7 +1223,7 @@ mod tests {
             self.allocated_pages.borrow_mut().push(addr);
 
             if is_root {
-                BASE.store(addr, Ordering::Relaxed);
+                BASE.store(addr, std::sync::atomic::Ordering::Relaxed);
             }
 
             Ok(addr)
@@ -1250,11 +1250,11 @@ mod tests {
         };
 
         // By default, the table is not active, so should be Inactive
-        ACTIVE.store(false, Ordering::Relaxed);
+        ACTIVE.store(false, std::sync::atomic::Ordering::Relaxed);
         assert_eq!(pt.get_state(), PageTableState::Inactive);
 
         // Set table as active, but self-map entry is not present or doesn't match base
-        ACTIVE.store(true, Ordering::Relaxed);
+        ACTIVE.store(true, std::sync::atomic::Ordering::Relaxed);
 
         // Overwrite the self-map entry to not present
         let root_level = PageLevel::root_level(pt.paging_type);

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -1089,13 +1089,15 @@ mod tests {
     use super::*;
     use std::{
         alloc::{Layout, alloc_zeroed},
-        cell::Cell,
+        sync::{
+            Mutex, MutexGuard, PoisonError,
+            atomic::{AtomicBool, AtomicU64, Ordering},
+        },
     };
 
-    thread_local! {
-        static ACTIVE: Cell<bool> = const { Cell::new(false) };
-        static BASE: Cell<u64> = const { Cell::new(0) };
-    }
+    static ACTIVE: AtomicBool = AtomicBool::new(false);
+    static BASE: AtomicU64 = AtomicU64::new(0);
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     // Dummy Arch implementation for testing
     #[derive(PartialEq, Debug)]
@@ -1110,7 +1112,7 @@ mod tests {
         }
         fn get_self_mapped_base(_level: PageLevel, _va: VirtualAddress, _paging_type: PagingType) -> u64 {
             // for the test we can't use the real self map, so just return the PT base
-            BASE.with(|base| base.get())
+            BASE.load(Ordering::Relaxed)
         }
         fn get_zero_va(_paging_type: PagingType) -> Result<VirtualAddress, PtError> {
             Ok(VirtualAddress::new(0x1000))
@@ -1119,7 +1121,7 @@ mod tests {
             Ok(VirtualAddress::new(0xFFFF_FFFF_FFFF_0000))
         }
         fn is_table_active(_base: u64) -> bool {
-            ACTIVE.with(|active| active.get())
+            ACTIVE.load(Ordering::Relaxed)
         }
         unsafe fn zero_page(_va: VirtualAddress) {}
         unsafe fn install_page_table(_base: u64, _paging_type: PagingType) -> Result<(), PtError> {
@@ -1221,23 +1223,26 @@ mod tests {
             self.allocated_pages.borrow_mut().push(addr);
 
             if is_root {
-                BASE.with(|base| base.set(addr));
+                BASE.store(addr, Ordering::Relaxed);
             }
 
             Ok(addr)
         }
     }
 
-    fn make_table() -> (PageTableInternal<DummyAllocator, DummyArch>, DummyAllocator) {
+    fn make_table() -> (PageTableInternal<DummyAllocator, DummyArch>, DummyAllocator, MutexGuard<'static, ()>) {
+        // Hold the shared-state lock for as long as the returned table is alive so concurrent tests
+        // cannot mutate the global `BASE`/`ACTIVE` out from under it.
+        let guard = TEST_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
         let allocator = DummyAllocator::new();
         let allocator_clone = allocator.clone();
         let pt = PageTableInternal::new(allocator, PagingType::Paging4Level).unwrap();
-        (pt, allocator_clone)
+        (pt, allocator_clone, guard)
     }
 
     #[test]
     fn test_get_state_variants() {
-        let (pt, allocator) = make_table();
+        let (pt, allocator, _guard) = make_table();
 
         // Cleanup function to ensure memory is freed
         let cleanup = || {
@@ -1245,11 +1250,11 @@ mod tests {
         };
 
         // By default, the table is not active, so should be Inactive
-        ACTIVE.with(|active| active.set(false));
+        ACTIVE.store(false, Ordering::Relaxed);
         assert_eq!(pt.get_state(), PageTableState::Inactive);
 
         // Set table as active, but self-map entry is not present or doesn't match base
-        ACTIVE.with(|active| active.set(true));
+        ACTIVE.store(true, Ordering::Relaxed);
 
         // Overwrite the self-map entry to not present
         let root_level = PageLevel::root_level(pt.paging_type);
@@ -1275,7 +1280,7 @@ mod tests {
 
     #[test]
     fn test_validate_address_range() {
-        let (pt, allocator) = make_table();
+        let (pt, allocator, _guard) = make_table();
 
         assert!(pt.validate_address_range(VirtualAddress::new(0x1000), 0x2000).is_ok());
         assert_eq!(pt.validate_address_range(VirtualAddress::new(0x1001), 0x2000), Err(PtError::UnalignedAddress));
@@ -1287,7 +1292,7 @@ mod tests {
 
     #[test]
     fn test_allocate_page_alignment() {
-        let (mut pt, allocator) = make_table();
+        let (mut pt, allocator, _guard) = make_table();
         let pa: u64 = pt.allocate_page(PageTableState::Inactive).unwrap().into();
         assert_eq!(pa % PAGE_SIZE, 0);
 
@@ -1296,7 +1301,7 @@ mod tests {
 
     #[test]
     fn test_split_large_page_error() {
-        let (mut pt, allocator) = make_table();
+        let (mut pt, allocator, _guard) = make_table();
         let mut entry = DummyPTE::new();
         entry.set_present_bit(false, VirtualAddress::new(0x0));
         let res =
@@ -1331,7 +1336,7 @@ mod tests {
 
     #[test]
     fn test_dump_page_tables_invalid_range() {
-        let (pt, allocator) = make_table();
+        let (pt, allocator, _guard) = make_table();
         let res = pt.dump_page_tables(0x1001, 0x1000);
         assert_eq!(res, Err(PtError::InvalidMemoryRange));
 
@@ -1355,7 +1360,7 @@ mod tests {
 
     #[test]
     fn test_map_memory_region_top_va_overflow() {
-        let (mut pt, allocator) = make_table();
+        let (mut pt, allocator, _guard) = make_table();
         // max_va is 0xFFFF_FFFF_FFFF_0000, so use an address near the top and a size that overflows
         let addr = 0xFFFF_FFFF_FFFF_0000;
         let size = 0x2000; // This will make top_va > max_va
@@ -1367,7 +1372,7 @@ mod tests {
 
     #[test]
     fn test_unmap_memory_region_top_va_overflow() {
-        let (mut pt, allocator) = make_table();
+        let (mut pt, allocator, _guard) = make_table();
         let addr = 0xFFFF_FFFF_FFFF_0000;
         let size = 0x2000;
         let res = pt.unmap_memory_region(addr, size);
@@ -1382,7 +1387,7 @@ mod tests {
         // level to the page table base, so the walk reads the root table for each level. A freshly
         // created table exposes no genuine leaf mappings, so the iterator yields nothing, but the
         // `ActiveSelfMapped` branch of the iterator's state handling is still executed.
-        let (pt, allocator) = make_table();
+        let (pt, allocator, _guard) = make_table();
 
         let count =
             PageTableIterator::<DummyArch>::new(pt.base, pt.paging_type, PageTableState::ActiveSelfMapped, None)

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -1093,10 +1093,6 @@ mod tests {
         sync::atomic::{AtomicBool, AtomicU64},
     };
 
-    // `DummyArch` emulates hardware state through these process-wide statics. Tests that build a
-    // `DummyArch` page table are marked `#[serial]` so the libtest harness never runs them
-    // concurrently; otherwise one test's `make_table()` could overwrite `BASE` while another walks
-    // its own table in self-mapped mode. See issue #215.
     static ACTIVE: AtomicBool = AtomicBool::new(false);
     static BASE: AtomicU64 = AtomicU64::new(0);
 


### PR DESCRIPTION
## Description

The current iterator tests access some global variables. However, the tests are dispatched concurrently, and could cause the tests to fail.

This change adds a lock before making the table to guard against the test from running at the same time.

Resolves #215 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested locally and did not run into problems.

## Integration Instructions

N/A
