### PR TITLE
Switch from coverage_nightly to coverage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,4 @@ ci_features = ["supervisor"]
 [lints.rust]
 # Set by cargo-llvm-cov during coverage runs. Declared here so gating
 # `coverage_attribute` behind it does not trigger unexpected_cfgs warnings.
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -183,7 +183,7 @@ install_crate = false
 clear = true
 # `coverage_attribute` is deliberately excluded from the default allow-features in
 # .cargo/config.toml so ungated `#[coverage(off)]` fails to compile. Coverage runs set the
-# `coverage_nightly` cfg (set by cargo-llvm-cov), which needs the feature, so re-add it here.
+# `coverage` cfg (set by cargo-llvm-cov), which needs the feature, so re-add it here.
 # Note: RUSTFLAGS replaces build.rustflags.
 env = { RUSTFLAGS = "-Z allow-features=c_variadic,allocator_api,coverage_attribute" }
 command = "cargo"

--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -18,12 +18,12 @@ use crate::{
     structs::{VirtualAddress, *},
 };
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 // Reg implements hardware abstractions, which cannot be meaningfully tested in unit tests.
 mod reg;
 mod structs;
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests;
 
 const MAX_VA_BITS: u64 = 48;
@@ -141,7 +141,7 @@ impl<P: PageAllocator> AArch64PageTable<P> {
     /// Additionally, the caller is responsible for ensuring that paging is enabled
     /// and the page table is a completely valid structure.
     ///
-    #[cfg_attr(coverage_nightly, coverage(off))] // This requires hardware for meaningful testing.
+    #[cfg_attr(coverage, coverage(off))] // This requires hardware for meaningful testing.
     pub unsafe fn open_active(page_allocator: P) -> Result<Self, PtError> {
         let base = reg::get_ttbr0();
         let paging_type = detect_paging_type()?;
@@ -152,7 +152,7 @@ impl<P: PageAllocator> AArch64PageTable<P> {
 }
 
 /// Detect whether 4-level or 5-level paging is active by reading TCR.T0SZ.
-#[cfg_attr(coverage_nightly, coverage(off))] // This requires hardware for meaningful testing.
+#[cfg_attr(coverage, coverage(off))] // This requires hardware for meaningful testing.
 fn detect_paging_type() -> Result<PagingType, PtError> {
     let tcr = reg::get_tcr();
     let tg0 = (tcr >> 14) & 0b11; // TG0 is bits [15:14]
@@ -242,7 +242,7 @@ impl PageTableHal for PageTableArchAArch64 {
 
     /// SAFETY: This function is unsafe because it updates the HW page table registers to install a new page table.
     /// The caller must ensure that the base address is valid and points to a properly constructed page table.
-    #[cfg_attr(coverage_nightly, coverage(off))] // This manipulates hardware registers that can't be meaningfully tested.
+    #[cfg_attr(coverage, coverage(off))] // This manipulates hardware registers that can't be meaningfully tested.
     unsafe fn install_page_table(base: u64, paging_type: PagingType) -> Result<(), PtError> {
         if paging_type != PagingType::Paging4Level {
             log::error!("Only 4-level page tables are supported on AArch64");

--- a/src/aarch64/reg.rs
+++ b/src/aarch64/reg.rs
@@ -287,7 +287,7 @@ pub(crate) unsafe fn zero_page(page: u64) {
 ///
 /// The caller is responsible for ensuring that the provided TTBR0 is a valid address and the memory backing
 /// the page tables has the appropriate lifetime to be installed in system registers.
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 pub(crate) unsafe fn swap_page_tables(_ttbr0: u64, _tcr: u64, _mair: u64) {
     #[cfg(all(not(test), target_arch = "aarch64"))]
     {

--- a/src/aarch64/structs.rs
+++ b/src/aarch64/structs.rs
@@ -352,7 +352,7 @@ impl crate::arch::PageTableEntry for PageTableEntryAArch64 {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use crate::arch::PageTableEntry;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@
 //!
 
 #![cfg_attr(not(test), no_std)]
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage, feature(coverage_attribute))]
 
 pub mod aarch64;
 pub(crate) mod arch;
@@ -87,7 +87,7 @@ pub mod page_allocator;
 pub(crate) mod paging;
 pub(crate) mod structs;
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests;
 pub mod x64;
 use bitflags::bitflags;

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -1084,7 +1084,7 @@ impl<'a, Arch: PageTableHal> PageTableRange<'a, Arch> {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use serial_test::serial;

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -248,7 +248,7 @@ impl From<VirtualAddress> for PhysicalAddress {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
 

--- a/src/x64.rs
+++ b/src/x64.rs
@@ -12,7 +12,7 @@ use core::ptr;
 
 mod structs;
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests;
 
 use structs::{CR3_PAGE_BASE_ADDRESS_MASK, MAX_VA_4_LEVEL, MAX_VA_5_LEVEL, ZERO_VA_4_LEVEL, ZERO_VA_5_LEVEL};
@@ -93,7 +93,7 @@ impl<P: PageAllocator> X64PageTable<P> {
     /// This is unsafe because it creates a second manager for the currently
     /// active page tables. The caller must ensure that no other code modifies
     /// the page tables while this manager is in use.
-    #[cfg_attr(coverage_nightly, coverage(off))] // This requires hardware for meaningful testing.
+    #[cfg_attr(coverage, coverage(off))] // This requires hardware for meaningful testing.
     pub unsafe fn open_active(page_allocator: P) -> Result<Self, PtError> {
         let base = read_cr3() & CR3_PAGE_BASE_ADDRESS_MASK;
         let paging_type = detect_paging_type()?;
@@ -367,7 +367,7 @@ fn read_cr3() -> u64 {
 const CR4_LA57: u64 = 1 << 12;
 
 /// Read CR4 register.
-#[cfg_attr(coverage_nightly, coverage(off))] // This requires hardware for meaningful testing.
+#[cfg_attr(coverage, coverage(off))] // This requires hardware for meaningful testing.
 fn read_cr4() -> u64 {
     let mut _value = 0u64;
 
@@ -384,7 +384,7 @@ fn read_cr4() -> u64 {
 }
 
 /// Detect whether 4-level or 5-level paging is active by reading CR4.LA57.
-#[cfg_attr(coverage_nightly, coverage(off))] // This requires hardware for meaningful testing.
+#[cfg_attr(coverage, coverage(off))] // This requires hardware for meaningful testing.
 fn detect_paging_type() -> Result<PagingType, PtError> {
     if read_cr4() & CR4_LA57 != 0 { Ok(PagingType::Paging5Level) } else { Ok(PagingType::Paging4Level) }
 }

--- a/src/x64/structs.rs
+++ b/src/x64/structs.rs
@@ -319,7 +319,7 @@ impl crate::arch::PageTableEntry for PageTableEntryX64 {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 mod tests {
     use super::*;
     use crate::{


### PR DESCRIPTION
## Description

Since the repo is currently using the stable toolchain, switch from gating `coverage_attribute` on `coverage_nightly` to `coverage` per https://github.com/taiki-e/cargo-llvm-cov.

This is set automatically by `cargo-llvm-cov`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make coverage`

Checked the environment configured by `cargo-llvm-cov` in my local workspace:

```
cargo llvm-cov show-env
info: cargo-llvm-cov currently setting cfg(coverage); you can opt-out it by passing --no-cfg-coverage
RUSTFLAGS="-Z allow-features=c_variadic,allocator_api -C instrument-coverage --cfg=coverage --cfg=trybuild_no_target"
LLVM_PROFILE_FILE=patina-paging\target\patina-paging-%p-%16m.profraw
CARGO_LLVM_COV=1
CARGO_LLVM_COV_SHOW_ENV=1
CARGO_LLVM_COV_TARGET_DIR=patina-paging\target
```

## Integration Instructions

- N/A

---

- patina-devops synced files will be updated in a single PR in that repo.