### PR TITLE
Remove `doc` feature in favor of doc `cfg`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,6 @@ description = "Paging library for AArch64 & X64 architectures"
 repository = "https://github.com/OpenDevicePartnership/patina-paging"
 keywords = ["paging"]
 
-[package.metadata.docs.rs]
-features = ["doc"]
-
 [dependencies]
 bitfield-struct = "0.13"
 bitflags = "2.6.0"
@@ -20,7 +17,6 @@ cfg-if = "1.0.0"
 serial_test = "3.5"
 
 [features]
-doc = []
 supervisor = []
 # All no_std features to test in CI
 ci_features = ["supervisor"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -288,13 +288,13 @@ args = ["clippy", "--all-targets", "--all-features", "--", "-D", "warnings"]
 env = { RUSTDOCFLAGS = "-D warnings"}
 description = "Builds all rust documentation in the workspace. Example `cargo make doc`"
 command = "cargo"
-args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc", "--no-deps"]
+args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--no-deps"]
 
 [tasks.doc-open]
 env = { RUSTDOCFLAGS = "-D warnings"}
 description = "Builds all rust documentation in the workspace and opens the documentation Example `cargo make doc-open`"
 command = "cargo"
-args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc", "--open"]
+args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--open"]
 
 [tasks.fmt]
 description = "Run cargo format."


### PR DESCRIPTION
## Description

Sync'd files are also updated via this PR: https://github.com/OpenDevicePartnership/patina-devops/pull/183

ref: [doc cfg functionality](https://doc.rust-lang.org/rustdoc/advanced-features.html#cfgdoc-documenting-platform-specific-or-feature-specific-information)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
