### PR TITLE
Update Miri workflow tool installing

### DIFF
--- a/.github/workflows/MiriWorkflow.yml
+++ b/.github/workflows/MiriWorkflow.yml
@@ -44,13 +44,11 @@ jobs:
       - name: Run Miri Tests
         env:
           MIRIFLAGS: "-Zmiri-disable-stacked-borrows"
-          NEXTEST_EXPERIMENTAL_LIBTEST_JSON: "1"
-          NEXTEST_TEST_THREADS: "8"
-          NEXTEST_MESSAGE_FORMAT: "libtest-json"
         run: |
           filters=$(printf "%s" "${{ inputs.test-filter }}")
           set +e  # Disable exit on error
-          cargo +nightly miri nextest run --lib --no-fail-fast $filters | tee results.log
+          cargo +nightly miri test --lib --no-fail-fast -- --format json -Z unstable-options $filters | tee results.log
+          test_status=${PIPESTATUS[0]}
           set -e  # Re-enable exit on error
 
           grep '^{' results.log | jq -r 'select(.type == "test" and .event == "failed")' > failed_tests.json
@@ -58,7 +56,7 @@ jobs:
           if [ -s failed_tests.json ]; then
             exit 1  # Fail the job if there are test failures
           fi
-          exit 0
+          exit $test_status
 
       - name: Report Miri Test Failures
         if: failure() && inputs.create-issue

--- a/.github/workflows/MiriWorkflow.yml
+++ b/.github/workflows/MiriWorkflow.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: 🛠️ Download Rust Tools 🛠️
-        uses: OpenDevicePartnership/patina-devops/.github/actions/rust-tool-cache@v0.2.2
+        uses: OpenDevicePartnership/patina-devops/.github/actions/rust-tool-cache@v0.3.14
 
       - name: Install miri
         run: rustup +nightly component add miri

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -21,7 +21,6 @@ mdbook = "0.4.52"
 mdbook-admonish = "1.20.0"
 mdbook-linkcheck = "0.7.7"
 mdbook-mermaid = "0.16.2"
-cargo-nextest = "0.9.140"
 
 [msrv]
 channel = "1.89.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -21,6 +21,7 @@ mdbook = "0.4.52"
 mdbook-admonish = "1.20.0"
 mdbook-linkcheck = "0.7.7"
 mdbook-mermaid = "0.16.2"
+cargo-nextest = "0.9.140"
 
 [msrv]
 channel = "1.89.0"


### PR DESCRIPTION
## Description

Resolves the 2 following bugs in the miri workflow:

- Update the version of Rust tool cache action so that it can handle when `[tools]` is not the last entry in the `rust-toolchain.toml` file.
- Update the Miri workflow to use `test` instead of `nextest` since the `rust-toolchain.toml` is sync'd across all repositories and overriding is not supported.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

https://github.com/OpenDevicePartnership/patina-paging/actions/runs/30842391356

## Integration Instructions

N/A
